### PR TITLE
fix: enable filtering for pingprobes

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -3235,9 +3235,9 @@ PingResult.
 
 #### Relations
 
-##### `GET /pingprobes`
+##### `GET /pingprobes/:id`
 
-Retrieves a ping probe.
+Retrieves a ping result.
 
 Parameters:
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -3235,6 +3235,14 @@ PingResult.
 
 #### Relations
 
+##### `GET /pingprobes`
+
+Retrieves a ping probe.
+
+Parameters:
+
+- `q` (`string`): Filtering query. Consequent `q` parameters will form an or.
+
 ##### `POST /processingunits/:id/pingprobes`
 
 Create a ping probe.

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -3239,10 +3239,6 @@ PingResult.
 
 Retrieves a ping result.
 
-Parameters:
-
-- `q` (`string`): Filtering query. Consequent `q` parameters will form an or.
-
 ##### `POST /processingunits/:id/pingprobes`
 
 Create a ping probe.

--- a/relationships_registry.go
+++ b/relationships_registry.go
@@ -3066,6 +3066,28 @@ func init() {
 		Create: map[string]*elemental.RelationshipInfo{
 			"processingunit": {},
 		},
+		RetrieveMany: map[string]*elemental.RelationshipInfo{
+			"root": {
+				Parameters: []elemental.ParameterDefinition{
+					{
+						Name:     "q",
+						Type:     "string",
+						Multiple: true,
+					},
+				},
+			},
+		},
+		Info: map[string]*elemental.RelationshipInfo{
+			"root": {
+				Parameters: []elemental.ParameterDefinition{
+					{
+						Name:     "q",
+						Type:     "string",
+						Multiple: true,
+					},
+				},
+			},
+		},
 	}
 
 	relationshipsRegistry[PingRequestIdentity] = &elemental.Relationship{

--- a/relationships_registry.go
+++ b/relationships_registry.go
@@ -3067,15 +3067,7 @@ func init() {
 			"processingunit": {},
 		},
 		Retrieve: map[string]*elemental.RelationshipInfo{
-			"root": {
-				Parameters: []elemental.ParameterDefinition{
-					{
-						Name:     "q",
-						Type:     "string",
-						Multiple: true,
-					},
-				},
-			},
+			"root": {},
 		},
 	}
 

--- a/relationships_registry.go
+++ b/relationships_registry.go
@@ -3066,18 +3066,7 @@ func init() {
 		Create: map[string]*elemental.RelationshipInfo{
 			"processingunit": {},
 		},
-		RetrieveMany: map[string]*elemental.RelationshipInfo{
-			"root": {
-				Parameters: []elemental.ParameterDefinition{
-					{
-						Name:     "q",
-						Type:     "string",
-						Multiple: true,
-					},
-				},
-			},
-		},
-		Info: map[string]*elemental.RelationshipInfo{
+		Retrieve: map[string]*elemental.RelationshipInfo{
 			"root": {
 				Parameters: []elemental.ParameterDefinition{
 					{

--- a/specs/pingprobe.spec
+++ b/specs/pingprobe.spec
@@ -8,6 +8,10 @@ model:
   description: |-
     Represents the result of a unique ping probe. They are aggregated into a
     PingResult.
+  get:
+    description: Retrieves a ping result.
+    global_parameters:
+    - $filtering
   extends:
   - '@zoned'
   - '@migratable'

--- a/specs/pingprobe.spec
+++ b/specs/pingprobe.spec
@@ -10,8 +10,6 @@ model:
     PingResult.
   get:
     description: Retrieves a ping result.
-    global_parameters:
-    - $filtering
   extends:
   - '@zoned'
   - '@migratable'

--- a/specs/root.spec
+++ b/specs/root.spec
@@ -615,6 +615,12 @@ relations:
   create:
     description: Creates a new PCC provider.
 
+- rest_name: pingprobe
+  get:
+    description: Retrieves a ping probe.
+    global_parameters:
+    - $filtering
+
 - rest_name: pingrequest
   create:
     description: Initiate a new the ping request.

--- a/specs/root.spec
+++ b/specs/root.spec
@@ -615,12 +615,6 @@ relations:
   create:
     description: Creates a new PCC provider.
 
-- rest_name: pingprobe
-  get:
-    description: Retrieves a ping probe.
-    global_parameters:
-    - $filtering
-
 - rest_name: pingrequest
   create:
     description: Initiate a new the ping request.


### PR DESCRIPTION
Used for retrieving ping probes from a remote namespace using probe ID.