### PR TITLE
Changed network policy port validation to $serviceports

### DIFF
--- a/networkaccesspolicy.go
+++ b/networkaccesspolicy.go
@@ -904,7 +904,7 @@ func (o *NetworkAccessPolicy) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := ValidateProtoPorts("ports", o.Ports); err != nil {
+	if err := ValidateServicePorts("ports", o.Ports); err != nil {
 		errors = errors.Append(err)
 	}
 

--- a/specs/networkaccesspolicy.spec
+++ b/specs/networkaccesspolicy.spec
@@ -150,7 +150,7 @@ attributes:
     subtype: string
     orderable: true
     validations:
-    - $protoports
+    - $serviceports
 
   - name: subject
     description: A tag or tag expression identifying the subject of the policy.


### PR DESCRIPTION
To support port ranges in network policy, it should use the same validation function as the external network.

Currently, the network policy uses:

  - name: ports
    description: Represents the ports and protocols this policy applies to.
    type: list
    exposed: true
    subtype: string
    orderable: true
    validations:
    - $protoports <---- which maps to the ValidateProtoPorts custom validation

The external network defines:

  - name: servicePorts
    description: List of protocol/ports `(tcp/80)` or `(udp/80:100)`.
    type: list
    exposed: true
    subtype: string
    stored: true
    validations:
    - $serviceports <---- which maps to the ValidateServicePorts custom validation

Changing ports to use $serviceports 