### PR TITLE
Update: Use FQDN validation from same source as original regex

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -468,8 +468,8 @@ func ValidateOptionalTimeDuration(attribute string, duration string) error {
 	return ValidateTimeDuration(attribute, duration)
 }
 
-// hostname regex from github.com/go-playground/validator
-var hostnameRegexRFC1123 = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9\-\.]+[a-z-Az0-9]$`)
+// FQDN regex from github.com/go-playground/validator
+var fqdnRegexRFC1123 = regexp.MustCompile(`^([a-zA-Z0-9]{1}[a-zA-Z0-9_-]{0,62})(\.[a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62})*?(\.[a-zA-Z]{1}[a-zA-Z0-9]{0,62})\.?$`)
 
 func isFQDN(val string) bool {
 
@@ -477,11 +477,7 @@ func isFQDN(val string) bool {
 		return false
 	}
 
-	if val[len(val)-1] == '.' {
-		val = val[0 : len(val)-1]
-	}
-
-	return hostnameRegexRFC1123.MatchString(val)
+	return fqdnRegexRFC1123.MatchString(val)
 }
 
 func ipNetFromString(ip string) (*net.IPNet, error) {

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -1943,6 +1943,20 @@ func Test_isFQDN(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"invalid one",
+			args{
+				"sdfjsdjfs",
+			},
+			false,
+		},
+		{
+			"empty",
+			args{
+				"",
+			},
+			false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description
Prior to this PR, we were using the hostname regex from github.com/go-playground/validator to validate FQDNs which is why a simple string like `asdasd` would match. Fortunately, they added an FQDN regex just 3 months back which also supported a trailing dot. Added that, simplified, and added a couple more unit tests to cover what found the issue and a path in the code that was missed.

> Fixes: https://github.com/aporeto-inc/aporeto-devs/issues/723