### PR TITLE
Revert "Update: Use FQDN validation from same source (#541)"

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -468,8 +468,8 @@ func ValidateOptionalTimeDuration(attribute string, duration string) error {
 	return ValidateTimeDuration(attribute, duration)
 }
 
-// FQDN regex from github.com/go-playground/validator
-var fqdnRegexRFC1123 = regexp.MustCompile(`^([a-zA-Z0-9]{1}[a-zA-Z0-9_-]{0,62})(\.[a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62})*?(\.[a-zA-Z]{1}[a-zA-Z0-9]{0,62})\.?$`)
+// hostname regex from github.com/go-playground/validator
+var hostnameRegexRFC1123 = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9\-\.]+[a-z-Az0-9]$`)
 
 func isFQDN(val string) bool {
 
@@ -477,7 +477,11 @@ func isFQDN(val string) bool {
 		return false
 	}
 
-	return fqdnRegexRFC1123.MatchString(val)
+	if val[len(val)-1] == '.' {
+		val = val[0 : len(val)-1]
+	}
+
+	return hostnameRegexRFC1123.MatchString(val)
 }
 
 func ipNetFromString(ip string) (*net.IPNet, error) {

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -1943,20 +1943,6 @@ func Test_isFQDN(t *testing.T) {
 			},
 			false,
 		},
-		{
-			"invalid one",
-			args{
-				"sdfjsdjfs",
-			},
-			false,
-		},
-		{
-			"empty",
-			args{
-				"",
-			},
-			false,
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### Description
This is just in case we need to revert the regex due to needing to support basic hostnames as well.