### PR TITLE
modify flowreport for compatibility with new flowrecordcache

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -12133,7 +12133,7 @@ Port of the destination.
 
 ##### `destinationType` [`required`]
 
-Type: `enum(ProcessingUnit | ExternalNetwork | Claims)`
+Type: `enum(ProcessingUnit | ExternalNetwork | Claims | OfflineProcessingUnit)`
 
 Destination type.
 
@@ -12290,7 +12290,7 @@ property does nothing.
 
 ##### `sourceType` [`required`]
 
-Type: `enum(ProcessingUnit | ExternalNetwork | Claims)`
+Type: `enum(ProcessingUnit | ExternalNetwork | Claims | OfflineProcessingUnit)`
 
 Type of the source.
 

--- a/flowreport.go
+++ b/flowreport.go
@@ -30,6 +30,9 @@ const (
 	// FlowReportDestinationTypeExternalNetwork represents the value ExternalNetwork.
 	FlowReportDestinationTypeExternalNetwork FlowReportDestinationTypeValue = "ExternalNetwork"
 
+	// FlowReportDestinationTypeOfflineProcessingUnit represents the value OfflineProcessingUnit.
+	FlowReportDestinationTypeOfflineProcessingUnit FlowReportDestinationTypeValue = "OfflineProcessingUnit"
+
 	// FlowReportDestinationTypeProcessingUnit represents the value ProcessingUnit.
 	FlowReportDestinationTypeProcessingUnit FlowReportDestinationTypeValue = "ProcessingUnit"
 )
@@ -74,6 +77,9 @@ const (
 
 	// FlowReportSourceTypeExternalNetwork represents the value ExternalNetwork.
 	FlowReportSourceTypeExternalNetwork FlowReportSourceTypeValue = "ExternalNetwork"
+
+	// FlowReportSourceTypeOfflineProcessingUnit represents the value OfflineProcessingUnit.
+	FlowReportSourceTypeOfflineProcessingUnit FlowReportSourceTypeValue = "OfflineProcessingUnit"
 
 	// FlowReportSourceTypeProcessingUnit represents the value ProcessingUnit.
 	FlowReportSourceTypeProcessingUnit FlowReportSourceTypeValue = "ProcessingUnit"
@@ -605,7 +611,7 @@ func (o *FlowReport) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("destinationType", string(o.DestinationType), []string{"ProcessingUnit", "ExternalNetwork", "Claims"}, false); err != nil {
+	if err := elemental.ValidateStringInList("destinationType", string(o.DestinationType), []string{"ProcessingUnit", "ExternalNetwork", "Claims", "OfflineProcessingUnit"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -641,7 +647,7 @@ func (o *FlowReport) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("sourceType", string(o.SourceType), []string{"ProcessingUnit", "ExternalNetwork", "Claims"}, false); err != nil {
+	if err := elemental.ValidateStringInList("sourceType", string(o.SourceType), []string{"ProcessingUnit", "ExternalNetwork", "Claims", "OfflineProcessingUnit"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -807,7 +813,7 @@ property does nothing.`,
 		Type:           "integer",
 	},
 	"DestinationType": {
-		AllowedChoices: []string{"ProcessingUnit", "ExternalNetwork", "Claims"},
+		AllowedChoices: []string{"ProcessingUnit", "ExternalNetwork", "Claims", "OfflineProcessingUnit"},
 		ConvertedName:  "DestinationType",
 		Description:    `Destination type.`,
 		Exposed:        true,
@@ -1004,7 +1010,7 @@ property does nothing.`,
 		Type:    "string",
 	},
 	"SourceType": {
-		AllowedChoices: []string{"ProcessingUnit", "ExternalNetwork", "Claims"},
+		AllowedChoices: []string{"ProcessingUnit", "ExternalNetwork", "Claims", "OfflineProcessingUnit"},
 		ConvertedName:  "SourceType",
 		Description:    `Type of the source.`,
 		Exposed:        true,
@@ -1086,7 +1092,7 @@ property does nothing.`,
 		Type:           "integer",
 	},
 	"destinationtype": {
-		AllowedChoices: []string{"ProcessingUnit", "ExternalNetwork", "Claims"},
+		AllowedChoices: []string{"ProcessingUnit", "ExternalNetwork", "Claims", "OfflineProcessingUnit"},
 		ConvertedName:  "DestinationType",
 		Description:    `Destination type.`,
 		Exposed:        true,
@@ -1283,7 +1289,7 @@ property does nothing.`,
 		Type:    "string",
 	},
 	"sourcetype": {
-		AllowedChoices: []string{"ProcessingUnit", "ExternalNetwork", "Claims"},
+		AllowedChoices: []string{"ProcessingUnit", "ExternalNetwork", "Claims", "OfflineProcessingUnit"},
 		ConvertedName:  "SourceType",
 		Description:    `Type of the source.`,
 		Exposed:        true,

--- a/specs/flowreport.spec
+++ b/specs/flowreport.spec
@@ -62,6 +62,7 @@ attributes:
     - ProcessingUnit
     - ExternalNetwork
     - Claims
+    - OfflineProcessingUnit
     example_value: ProcessingUnit
 
   - name: dropReason
@@ -218,6 +219,7 @@ attributes:
     - ProcessingUnit
     - ExternalNetwork
     - Claims
+    - OfflineProcessingUnit
     example_value: ProcessingUnit
 
   - name: timestamp


### PR DESCRIPTION
Since the flowrecordcache items will be converted into flowreports eventually, they will need to have almost all the same info in them. I don't know if there's an easier way in gaia, but please see this draft PR that just adds a desttype/sourcetype to represent "OfflineProcessingUnit".

So the idea is that if type is OfflineProcessingUnit, then DestinationID/SourceID will be understood to be a enforcer-local temp ID. The backend would need to process flowreports by forking its logic based on this: if `DestinationType==FlowReportDestinationTypeOfflineProcessingUnit` or `SourceType==FlowReportDestinationTypeOfflineProcessingUnit` then treat it as a flowrecordcache.

I believe `flowreport` could be aliased to `cachedflowrecord` but I don't think that would change anything in the backend processing logic. Is there a better way to do this?