### PR TITLE
Update: Revised namespace types

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -224,14 +224,12 @@ apiproxy
 apoctl
 aporeto-crds
 aporeto-operator
-app-234
 auditd
 authorizer
 autocomplete
 autocompletion
 autodiscover
 automations
-aws-123
 backend
 base64-encoded
 bolded
@@ -255,7 +253,6 @@ enum
 failover
 finack
 gRPC
-gcp-54
 georedundancy
 i.e.
 iOS

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -4837,7 +4837,7 @@ Default value:
 
 ##### `type` [`creation_only`]
 
-Type: `enum(Default | Tenant | CloudAccount | HostGroup | K8sClusterGroup | K8s)`
+Type: `enum(Default | Tenant | CloudAccount | HostGroup | KubernetesClusterGroup | Kubernetes)`
 
 The type defines the purpose of the namespace:
 - `Default`: A universal namespace that is capable of all actions and views.
@@ -4846,9 +4846,9 @@ The type defines the purpose of the namespace:
 account.
 - `HostGroup`: A child namespace of a cloud account that houses a managed
 non-Kubernetes group.
-- `K8sClusterGroup`: A child namespace of a cloud account that houses a managed
-Kubernetes group.
-- `K8s`: A child namespace of a Kubernetes cluster group that houses a
+- `KubernetesClusterGroup`: A child namespace of a cloud account that houses a
+managed Kubernetes group.
+- `Kubernetes`: A child namespace of a Kubernetes cluster group that houses a
 Kubernetes cluster (automatically created by the enforcer).
 
 Default value:

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -4837,15 +4837,19 @@ Default value:
 
 ##### `type` [`creation_only`]
 
-Type: `enum(Default | Tenant | CloudAccount | Group)`
+Type: `enum(Default | Tenant | CloudAccount | HostGroup | K8sClusterGroup | K8s)`
 
 The type defines the purpose of the namespace:
 - `Default`: A universal namespace that is capable of all actions and views.
 - `Tenant`: A namespace that houses a tenant (e.g. ACME).
 - `CloudAccount`: A child namespace of a tenant that houses a cloud provider
-account (e.g. aws-123, gcp-54).
-- `Group`: A child namespace of a cloud account that houses a managed group
-(e.g. marketing, app-234).
+account.
+- `HostGroup`: A child namespace of a cloud account that houses a managed
+non-Kubernetes group.
+- `K8sClusterGroup`: A child namespace of a cloud account that houses a managed
+Kubernetes group.
+- `K8s`: A child namespace of a Kubernetes cluster group that houses a
+Kubernetes cluster (automatically created by the enforcer).
 
 Default value:
 

--- a/namespace.go
+++ b/namespace.go
@@ -33,8 +33,14 @@ const (
 	// NamespaceTypeDefault represents the value Default.
 	NamespaceTypeDefault NamespaceTypeValue = "Default"
 
-	// NamespaceTypeGroup represents the value Group.
-	NamespaceTypeGroup NamespaceTypeValue = "Group"
+	// NamespaceTypeHostGroup represents the value HostGroup.
+	NamespaceTypeHostGroup NamespaceTypeValue = "HostGroup"
+
+	// NamespaceTypeK8s represents the value K8s.
+	NamespaceTypeK8s NamespaceTypeValue = "K8s"
+
+	// NamespaceTypeK8sClusterGroup represents the value K8sClusterGroup.
+	NamespaceTypeK8sClusterGroup NamespaceTypeValue = "K8sClusterGroup"
 
 	// NamespaceTypeTenant represents the value Tenant.
 	NamespaceTypeTenant NamespaceTypeValue = "Tenant"
@@ -201,9 +207,13 @@ type Namespace struct {
 	// - `Default`: A universal namespace that is capable of all actions and views.
 	// - `Tenant`: A namespace that houses a tenant (e.g. ACME).
 	// - `CloudAccount`: A child namespace of a tenant that houses a cloud provider
-	// account (e.g. aws-123, gcp-54).
-	// - `Group`: A child namespace of a cloud account that houses a managed group
-	// (e.g. marketing, app-234).
+	// account.
+	// - `HostGroup`: A child namespace of a cloud account that houses a managed
+	// non-Kubernetes group.
+	// - `K8sClusterGroup`: A child namespace of a cloud account that houses a managed
+	// Kubernetes group.
+	// - `K8s`: A child namespace of a Kubernetes cluster group that houses a
+	// Kubernetes cluster (automatically created by the enforcer).
 	Type NamespaceTypeValue `json:"type" msgpack:"type" bson:"type" mapstructure:"type,omitempty"`
 
 	// internal idempotency key for a update operation.
@@ -855,7 +865,7 @@ func (o *Namespace) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("type", string(o.Type), []string{"Default", "Tenant", "CloudAccount", "Group"}, false); err != nil {
+	if err := elemental.ValidateStringInList("type", string(o.Type), []string{"Default", "Tenant", "CloudAccount", "HostGroup", "K8sClusterGroup", "K8s"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -1256,7 +1266,7 @@ networks, enforcers) during their creation.`,
 		Type:           "string",
 	},
 	"Type": {
-		AllowedChoices: []string{"Default", "Tenant", "CloudAccount", "Group"},
+		AllowedChoices: []string{"Default", "Tenant", "CloudAccount", "HostGroup", "K8sClusterGroup", "K8s"},
 		ConvertedName:  "Type",
 		CreationOnly:   true,
 		DefaultValue:   NamespaceTypeDefault,
@@ -1264,9 +1274,13 @@ networks, enforcers) during their creation.`,
 - ` + "`" + `Default` + "`" + `: A universal namespace that is capable of all actions and views.
 - ` + "`" + `Tenant` + "`" + `: A namespace that houses a tenant (e.g. ACME).
 - ` + "`" + `CloudAccount` + "`" + `: A child namespace of a tenant that houses a cloud provider
-account (e.g. aws-123, gcp-54).
-- ` + "`" + `Group` + "`" + `: A child namespace of a cloud account that houses a managed group
-(e.g. marketing, app-234).`,
+account.
+- ` + "`" + `HostGroup` + "`" + `: A child namespace of a cloud account that houses a managed
+non-Kubernetes group.
+- ` + "`" + `K8sClusterGroup` + "`" + `: A child namespace of a cloud account that houses a managed
+Kubernetes group.
+- ` + "`" + `K8s` + "`" + `: A child namespace of a Kubernetes cluster group that houses a
+Kubernetes cluster (automatically created by the enforcer).`,
 		Exposed: true,
 		Name:    "type",
 		Stored:  true,
@@ -1660,7 +1674,7 @@ networks, enforcers) during their creation.`,
 		Type:           "string",
 	},
 	"type": {
-		AllowedChoices: []string{"Default", "Tenant", "CloudAccount", "Group"},
+		AllowedChoices: []string{"Default", "Tenant", "CloudAccount", "HostGroup", "K8sClusterGroup", "K8s"},
 		BSONFieldName:  "type",
 		ConvertedName:  "Type",
 		CreationOnly:   true,
@@ -1669,9 +1683,13 @@ networks, enforcers) during their creation.`,
 - ` + "`" + `Default` + "`" + `: A universal namespace that is capable of all actions and views.
 - ` + "`" + `Tenant` + "`" + `: A namespace that houses a tenant (e.g. ACME).
 - ` + "`" + `CloudAccount` + "`" + `: A child namespace of a tenant that houses a cloud provider
-account (e.g. aws-123, gcp-54).
-- ` + "`" + `Group` + "`" + `: A child namespace of a cloud account that houses a managed group
-(e.g. marketing, app-234).`,
+account.
+- ` + "`" + `HostGroup` + "`" + `: A child namespace of a cloud account that houses a managed
+non-Kubernetes group.
+- ` + "`" + `K8sClusterGroup` + "`" + `: A child namespace of a cloud account that houses a managed
+Kubernetes group.
+- ` + "`" + `K8s` + "`" + `: A child namespace of a Kubernetes cluster group that houses a
+Kubernetes cluster (automatically created by the enforcer).`,
 		Exposed: true,
 		Name:    "type",
 		Stored:  true,
@@ -1900,9 +1918,13 @@ type SparseNamespace struct {
 	// - `Default`: A universal namespace that is capable of all actions and views.
 	// - `Tenant`: A namespace that houses a tenant (e.g. ACME).
 	// - `CloudAccount`: A child namespace of a tenant that houses a cloud provider
-	// account (e.g. aws-123, gcp-54).
-	// - `Group`: A child namespace of a cloud account that houses a managed group
-	// (e.g. marketing, app-234).
+	// account.
+	// - `HostGroup`: A child namespace of a cloud account that houses a managed
+	// non-Kubernetes group.
+	// - `K8sClusterGroup`: A child namespace of a cloud account that houses a managed
+	// Kubernetes group.
+	// - `K8s`: A child namespace of a Kubernetes cluster group that houses a
+	// Kubernetes cluster (automatically created by the enforcer).
 	Type *NamespaceTypeValue `json:"type,omitempty" msgpack:"type,omitempty" bson:"type,omitempty" mapstructure:"type,omitempty"`
 
 	// internal idempotency key for a update operation.

--- a/namespace.go
+++ b/namespace.go
@@ -36,11 +36,11 @@ const (
 	// NamespaceTypeHostGroup represents the value HostGroup.
 	NamespaceTypeHostGroup NamespaceTypeValue = "HostGroup"
 
-	// NamespaceTypeK8s represents the value K8s.
-	NamespaceTypeK8s NamespaceTypeValue = "K8s"
+	// NamespaceTypeKubernetes represents the value Kubernetes.
+	NamespaceTypeKubernetes NamespaceTypeValue = "Kubernetes"
 
-	// NamespaceTypeK8sClusterGroup represents the value K8sClusterGroup.
-	NamespaceTypeK8sClusterGroup NamespaceTypeValue = "K8sClusterGroup"
+	// NamespaceTypeKubernetesClusterGroup represents the value KubernetesClusterGroup.
+	NamespaceTypeKubernetesClusterGroup NamespaceTypeValue = "KubernetesClusterGroup"
 
 	// NamespaceTypeTenant represents the value Tenant.
 	NamespaceTypeTenant NamespaceTypeValue = "Tenant"
@@ -210,9 +210,9 @@ type Namespace struct {
 	// account.
 	// - `HostGroup`: A child namespace of a cloud account that houses a managed
 	// non-Kubernetes group.
-	// - `K8sClusterGroup`: A child namespace of a cloud account that houses a managed
-	// Kubernetes group.
-	// - `K8s`: A child namespace of a Kubernetes cluster group that houses a
+	// - `KubernetesClusterGroup`: A child namespace of a cloud account that houses a
+	// managed Kubernetes group.
+	// - `Kubernetes`: A child namespace of a Kubernetes cluster group that houses a
 	// Kubernetes cluster (automatically created by the enforcer).
 	Type NamespaceTypeValue `json:"type" msgpack:"type" bson:"type" mapstructure:"type,omitempty"`
 
@@ -865,7 +865,7 @@ func (o *Namespace) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("type", string(o.Type), []string{"Default", "Tenant", "CloudAccount", "HostGroup", "K8sClusterGroup", "K8s"}, false); err != nil {
+	if err := elemental.ValidateStringInList("type", string(o.Type), []string{"Default", "Tenant", "CloudAccount", "HostGroup", "KubernetesClusterGroup", "Kubernetes"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -1266,7 +1266,7 @@ networks, enforcers) during their creation.`,
 		Type:           "string",
 	},
 	"Type": {
-		AllowedChoices: []string{"Default", "Tenant", "CloudAccount", "HostGroup", "K8sClusterGroup", "K8s"},
+		AllowedChoices: []string{"Default", "Tenant", "CloudAccount", "HostGroup", "KubernetesClusterGroup", "Kubernetes"},
 		ConvertedName:  "Type",
 		CreationOnly:   true,
 		DefaultValue:   NamespaceTypeDefault,
@@ -1277,9 +1277,9 @@ networks, enforcers) during their creation.`,
 account.
 - ` + "`" + `HostGroup` + "`" + `: A child namespace of a cloud account that houses a managed
 non-Kubernetes group.
-- ` + "`" + `K8sClusterGroup` + "`" + `: A child namespace of a cloud account that houses a managed
-Kubernetes group.
-- ` + "`" + `K8s` + "`" + `: A child namespace of a Kubernetes cluster group that houses a
+- ` + "`" + `KubernetesClusterGroup` + "`" + `: A child namespace of a cloud account that houses a
+managed Kubernetes group.
+- ` + "`" + `Kubernetes` + "`" + `: A child namespace of a Kubernetes cluster group that houses a
 Kubernetes cluster (automatically created by the enforcer).`,
 		Exposed: true,
 		Name:    "type",
@@ -1674,7 +1674,7 @@ networks, enforcers) during their creation.`,
 		Type:           "string",
 	},
 	"type": {
-		AllowedChoices: []string{"Default", "Tenant", "CloudAccount", "HostGroup", "K8sClusterGroup", "K8s"},
+		AllowedChoices: []string{"Default", "Tenant", "CloudAccount", "HostGroup", "KubernetesClusterGroup", "Kubernetes"},
 		BSONFieldName:  "type",
 		ConvertedName:  "Type",
 		CreationOnly:   true,
@@ -1686,9 +1686,9 @@ networks, enforcers) during their creation.`,
 account.
 - ` + "`" + `HostGroup` + "`" + `: A child namespace of a cloud account that houses a managed
 non-Kubernetes group.
-- ` + "`" + `K8sClusterGroup` + "`" + `: A child namespace of a cloud account that houses a managed
-Kubernetes group.
-- ` + "`" + `K8s` + "`" + `: A child namespace of a Kubernetes cluster group that houses a
+- ` + "`" + `KubernetesClusterGroup` + "`" + `: A child namespace of a cloud account that houses a
+managed Kubernetes group.
+- ` + "`" + `Kubernetes` + "`" + `: A child namespace of a Kubernetes cluster group that houses a
 Kubernetes cluster (automatically created by the enforcer).`,
 		Exposed: true,
 		Name:    "type",
@@ -1921,9 +1921,9 @@ type SparseNamespace struct {
 	// account.
 	// - `HostGroup`: A child namespace of a cloud account that houses a managed
 	// non-Kubernetes group.
-	// - `K8sClusterGroup`: A child namespace of a cloud account that houses a managed
-	// Kubernetes group.
-	// - `K8s`: A child namespace of a Kubernetes cluster group that houses a
+	// - `KubernetesClusterGroup`: A child namespace of a cloud account that houses a
+	// managed Kubernetes group.
+	// - `Kubernetes`: A child namespace of a Kubernetes cluster group that houses a
 	// Kubernetes cluster (automatically created by the enforcer).
 	Type *NamespaceTypeValue `json:"type,omitempty" msgpack:"type,omitempty" bson:"type,omitempty" mapstructure:"type,omitempty"`
 

--- a/specs/namespace.spec
+++ b/specs/namespace.spec
@@ -183,9 +183,9 @@ attributes:
       account.
       - `HostGroup`: A child namespace of a cloud account that houses a managed
       non-Kubernetes group.
-      - `K8sClusterGroup`: A child namespace of a cloud account that houses a managed
-      Kubernetes group.
-      - `K8s`: A child namespace of a Kubernetes cluster group that houses a
+      - `KubernetesClusterGroup`: A child namespace of a cloud account that houses a
+      managed Kubernetes group.
+      - `Kubernetes`: A child namespace of a Kubernetes cluster group that houses a
       Kubernetes cluster (automatically created by the enforcer).
     type: enum
     exposed: true
@@ -196,8 +196,8 @@ attributes:
     - Tenant
     - CloudAccount
     - HostGroup
-    - K8sClusterGroup
-    - K8s
+    - KubernetesClusterGroup
+    - Kubernetes
     default_value: Default
 
   - name: zoning

--- a/specs/namespace.spec
+++ b/specs/namespace.spec
@@ -180,9 +180,13 @@ attributes:
       - `Default`: A universal namespace that is capable of all actions and views.
       - `Tenant`: A namespace that houses a tenant (e.g. ACME).
       - `CloudAccount`: A child namespace of a tenant that houses a cloud provider
-      account (e.g. aws-123, gcp-54).
-      - `Group`: A child namespace of a cloud account that houses a managed group
-      (e.g. marketing, app-234).
+      account.
+      - `HostGroup`: A child namespace of a cloud account that houses a managed
+      non-Kubernetes group.
+      - `K8sClusterGroup`: A child namespace of a cloud account that houses a managed
+      Kubernetes group.
+      - `K8s`: A child namespace of a Kubernetes cluster group that houses a
+      Kubernetes cluster (automatically created by the enforcer).
     type: enum
     exposed: true
     stored: true
@@ -191,7 +195,9 @@ attributes:
     - Default
     - Tenant
     - CloudAccount
-    - Group
+    - HostGroup
+    - K8sClusterGroup
+    - K8s
     default_value: Default
 
   - name: zoning


### PR DESCRIPTION
#### Description
Namespace types have been revised to the following:
- Tenant
- CloudAccount
- HostGroup
- KubernetesClusterGroup
- Kubernetes

The bottom three are new and `Group` is removed.

> Fixes: https://redlock.atlassian.net/browse/CNS-454