### PR TITLE
Update: Bump travis to support two most recent minor language versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: go
 
 go:
-- 1.13.x
 - 1.14.x
+- 1.15.x
 
 env:
   global:
   - GO111MODULE=on
 
 before_install:
-- go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
+- go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.32.0
 
 script:
 - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - GO111MODULE=on
 
 before_install:
-- go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.32.0
+- go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
 
 script:
 - make


### PR DESCRIPTION
#### Description
golang v1.15.x has been out for a while, so we may as well move travis over to supporting it and dropping 1.13.x.