### PR TITLE
new: expose the VictoriaMetrics' '/api/v1/query' endpoint

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -403,6 +403,8 @@ localhost
 loopback
 macOS
 metadata
+MetricsQuery
+MetricsQueryRange
 misconfigured
 multipart
 namespace

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -16273,7 +16273,63 @@ List of suggested network policies.
 
 ## visualization/metrics
 
-### Metrics
+### MetricsQuery
+
+Prometheus compatible endpoint to evaluate a Prometheus query expression at a
+single instant or over a range of time. This can be used to retrieve back
+Aporeto specific metrics for a given namespace. All queries are protected within
+the namespace of the caller.
+
+#### Example
+
+```json
+{
+  "query": "flows{namespace=~\"/mycompany.*\"}",
+  "time": "2015-07-01T20:11:00.781Z"
+}
+```
+
+#### Relations
+
+##### `GET /metricsquery`
+
+Prometheus compatible endpoint to evaluate a Prometheus query expression at a
+single instant or over a range of time.
+
+Parameters:
+
+- `query` (`string`): Prometheus expression query string.
+- `time` (`string`): Evaluation timestamp <rfc3339 | unix_timestamp>.
+
+Mandatory Parameters
+
+`query`
+
+##### `POST /metricsquery`
+
+Prometheus compatible endpoint to evaluate a Prometheus query expression at a
+single instant or over a range of time.
+This has the same behavior as the GET request, however it is useful when
+specifying a large query that may breach server-side URL character limits. In
+such a case, you can URL-encode the parameters that would be used for a GET
+request directly in the request body by using the POST method and Content-Type:
+application/x-www-form-urlencoded header.
+
+#### Attributes
+
+##### `query` [`required`]
+
+Type: `string`
+
+Prometheus expression query string.
+
+##### `time`
+
+Type: `string`
+
+Evaluation timestamp <rfc3339 | unix_timestamp>.
+
+### MetricsQueryRange
 
 Prometheus compatible endpoint to evaluate an expression query over a range of
 time. This can be used to retrieve back Aporeto specific metrics for a given
@@ -16292,7 +16348,7 @@ namespace. All queries are protected within the namespace of the caller.
 
 #### Relations
 
-##### `GET /metrics`
+##### `GET /metricsqueryrange`
 
 Evaluates an expression query over a range of time returning a "matrix" result
 type.
@@ -16308,7 +16364,7 @@ Mandatory Parameters
 
 `query`
 
-##### `POST /metrics`
+##### `POST /metricsqueryrange`
 
 Evaluates an expression query over a range of time returning a "matrix" result.
 This has the same behavior as the GET request, however it is useful when
@@ -16329,7 +16385,7 @@ End timestamp <rfc3339 | unix_timestamp>.
 
 Type: `string`
 
-Contains the remote `POST` payload.
+Prometheus expression query string.
 
 ##### `start`
 

--- a/identities_registry.go
+++ b/identities_registry.go
@@ -88,7 +88,8 @@ var (
 		"log":                    LogIdentity,
 		"logout":                 LogoutIdentity,
 		"message":                MessageIdentity,
-		"metrics":                MetricsIdentity,
+		"metricsquery":           MetricsQueryIdentity,
+		"metricsqueryrange":      MetricsQueryRangeIdentity,
 		"namespace":              NamespaceIdentity,
 		"namespacemappingpolicy": NamespaceMappingPolicyIdentity,
 		"namespacepolicyinfo":    NamespacePolicyInfoIdentity,
@@ -253,7 +254,8 @@ var (
 		"logs":                     LogIdentity,
 		"logout":                   LogoutIdentity,
 		"messages":                 MessageIdentity,
-		"metrics":                  MetricsIdentity,
+		"metricsquery":             MetricsQueryIdentity,
+		"metricsqueryrange":        MetricsQueryRangeIdentity,
 		"namespaces":               NamespaceIdentity,
 		"namespacemappingpolicies": NamespaceMappingPolicyIdentity,
 		"namespacepolicyinfo":      NamespacePolicyInfoIdentity,
@@ -382,7 +384,8 @@ var (
 		"iapp":            InstalledAppIdentity,
 		"ip":              IsolationProfileIdentity,
 		"mess":            MessageIdentity,
-		"mq":              MetricsIdentity,
+		"mq":              MetricsQueryIdentity,
+		"mqr":             MetricsQueryRangeIdentity,
 		"ns":              NamespaceIdentity,
 		"nspolicy":        NamespaceMappingPolicyIdentity,
 		"nspolicies":      NamespaceMappingPolicyIdentity,
@@ -799,7 +802,8 @@ var (
 			{"name"},
 			{"createIdempotencyKey"},
 		},
-		"metrics": nil,
+		"metricsquery":      nil,
+		"metricsqueryrange": nil,
 		"namespace": {
 			{":shard", ":unique", "zone", "zHash"},
 			{"updateIdempotencyKey"},
@@ -1215,8 +1219,10 @@ func (f modelManager) Identifiable(identity elemental.Identity) elemental.Identi
 		return NewLogout()
 	case MessageIdentity:
 		return NewMessage()
-	case MetricsIdentity:
-		return NewMetrics()
+	case MetricsQueryIdentity:
+		return NewMetricsQuery()
+	case MetricsQueryRangeIdentity:
+		return NewMetricsQueryRange()
 	case NamespaceIdentity:
 		return NewNamespace()
 	case NamespaceMappingPolicyIdentity:
@@ -1520,8 +1526,10 @@ func (f modelManager) SparseIdentifiable(identity elemental.Identity) elemental.
 		return NewSparseLogout()
 	case MessageIdentity:
 		return NewSparseMessage()
-	case MetricsIdentity:
-		return NewSparseMetrics()
+	case MetricsQueryIdentity:
+		return NewSparseMetricsQuery()
+	case MetricsQueryRangeIdentity:
+		return NewSparseMetricsQueryRange()
 	case NamespaceIdentity:
 		return NewSparseNamespace()
 	case NamespaceMappingPolicyIdentity:
@@ -1833,8 +1841,10 @@ func (f modelManager) Identifiables(identity elemental.Identity) elemental.Ident
 		return &LogoutsList{}
 	case MessageIdentity:
 		return &MessagesList{}
-	case MetricsIdentity:
-		return &MetricsList{}
+	case MetricsQueryIdentity:
+		return &MetricsQueriesList{}
+	case MetricsQueryRangeIdentity:
+		return &MetricsQueryRangesList{}
 	case NamespaceIdentity:
 		return &NamespacesList{}
 	case NamespaceMappingPolicyIdentity:
@@ -2136,8 +2146,10 @@ func (f modelManager) SparseIdentifiables(identity elemental.Identity) elemental
 		return &SparseLogoutsList{}
 	case MessageIdentity:
 		return &SparseMessagesList{}
-	case MetricsIdentity:
-		return &SparseMetricsList{}
+	case MetricsQueryIdentity:
+		return &SparseMetricsQueriesList{}
+	case MetricsQueryRangeIdentity:
+		return &SparseMetricsQueryRangesList{}
 	case NamespaceIdentity:
 		return &SparseNamespacesList{}
 	case NamespaceMappingPolicyIdentity:
@@ -2380,7 +2392,8 @@ func AllIdentities() []elemental.Identity {
 		LogIdentity,
 		LogoutIdentity,
 		MessageIdentity,
-		MetricsIdentity,
+		MetricsQueryIdentity,
+		MetricsQueryRangeIdentity,
 		NamespaceIdentity,
 		NamespaceMappingPolicyIdentity,
 		NamespacePolicyInfoIdentity,
@@ -2685,9 +2698,13 @@ func AliasesForIdentity(identity elemental.Identity) []string {
 		return []string{
 			"mess",
 		}
-	case MetricsIdentity:
+	case MetricsQueryIdentity:
 		return []string{
 			"mq",
+		}
+	case MetricsQueryRangeIdentity:
+		return []string{
+			"mqr",
 		}
 	case NamespaceIdentity:
 		return []string{

--- a/metricsquery.go
+++ b/metricsquery.go
@@ -1,0 +1,507 @@
+package gaia
+
+import (
+	"fmt"
+
+	"github.com/globalsign/mgo/bson"
+	"github.com/mitchellh/copystructure"
+	"go.aporeto.io/elemental"
+)
+
+// MetricsQueryIdentity represents the Identity of the object.
+var MetricsQueryIdentity = elemental.Identity{
+	Name:     "metricsquery",
+	Category: "metricsquery",
+	Package:  "jenova",
+	Private:  false,
+}
+
+// MetricsQueriesList represents a list of MetricsQueries
+type MetricsQueriesList []*MetricsQuery
+
+// Identity returns the identity of the objects in the list.
+func (o MetricsQueriesList) Identity() elemental.Identity {
+
+	return MetricsQueryIdentity
+}
+
+// Copy returns a pointer to a copy the MetricsQueriesList.
+func (o MetricsQueriesList) Copy() elemental.Identifiables {
+
+	copy := append(MetricsQueriesList{}, o...)
+	return &copy
+}
+
+// Append appends the objects to the a new copy of the MetricsQueriesList.
+func (o MetricsQueriesList) Append(objects ...elemental.Identifiable) elemental.Identifiables {
+
+	out := append(MetricsQueriesList{}, o...)
+	for _, obj := range objects {
+		out = append(out, obj.(*MetricsQuery))
+	}
+
+	return out
+}
+
+// List converts the object to an elemental.IdentifiablesList.
+func (o MetricsQueriesList) List() elemental.IdentifiablesList {
+
+	out := make(elemental.IdentifiablesList, len(o))
+	for i := 0; i < len(o); i++ {
+		out[i] = o[i]
+	}
+
+	return out
+}
+
+// DefaultOrder returns the default ordering fields of the content.
+func (o MetricsQueriesList) DefaultOrder() []string {
+
+	return []string{}
+}
+
+// ToSparse returns the MetricsQueriesList converted to SparseMetricsQueriesList.
+// Objects in the list will only contain the given fields. No field means entire field set.
+func (o MetricsQueriesList) ToSparse(fields ...string) elemental.Identifiables {
+
+	out := make(SparseMetricsQueriesList, len(o))
+	for i := 0; i < len(o); i++ {
+		out[i] = o[i].ToSparse(fields...).(*SparseMetricsQuery)
+	}
+
+	return out
+}
+
+// Version returns the version of the content.
+func (o MetricsQueriesList) Version() int {
+
+	return 1
+}
+
+// MetricsQuery represents the model of a metricsquery
+type MetricsQuery struct {
+	// Prometheus expression query string.
+	Query string `json:"query" msgpack:"query" bson:"-" mapstructure:"query,omitempty"`
+
+	// Evaluation timestamp <rfc3339 | unix_timestamp>.
+	Time string `json:"time" msgpack:"time" bson:"-" mapstructure:"time,omitempty"`
+
+	ModelVersion int `json:"-" msgpack:"-" bson:"_modelversion"`
+}
+
+// NewMetricsQuery returns a new *MetricsQuery
+func NewMetricsQuery() *MetricsQuery {
+
+	return &MetricsQuery{
+		ModelVersion: 1,
+	}
+}
+
+// Identity returns the Identity of the object.
+func (o *MetricsQuery) Identity() elemental.Identity {
+
+	return MetricsQueryIdentity
+}
+
+// Identifier returns the value of the object's unique identifier.
+func (o *MetricsQuery) Identifier() string {
+
+	return ""
+}
+
+// SetIdentifier sets the value of the object's unique identifier.
+func (o *MetricsQuery) SetIdentifier(id string) {
+
+}
+
+// GetBSON implements the bson marshaling interface.
+// This is used to transparently convert ID to MongoDBID as ObectID.
+func (o *MetricsQuery) GetBSON() (interface{}, error) {
+
+	if o == nil {
+		return nil, nil
+	}
+
+	s := &mongoAttributesMetricsQuery{}
+
+	return s, nil
+}
+
+// SetBSON implements the bson marshaling interface.
+// This is used to transparently convert ID to MongoDBID as ObectID.
+func (o *MetricsQuery) SetBSON(raw bson.Raw) error {
+
+	if o == nil {
+		return nil
+	}
+
+	s := &mongoAttributesMetricsQuery{}
+	if err := raw.Unmarshal(s); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Version returns the hardcoded version of the model.
+func (o *MetricsQuery) Version() int {
+
+	return 1
+}
+
+// BleveType implements the bleve.Classifier Interface.
+func (o *MetricsQuery) BleveType() string {
+
+	return "metricsquery"
+}
+
+// DefaultOrder returns the list of default ordering fields.
+func (o *MetricsQuery) DefaultOrder() []string {
+
+	return []string{}
+}
+
+// Doc returns the documentation for the object
+func (o *MetricsQuery) Doc() string {
+
+	return `Prometheus compatible endpoint to evaluate a Prometheus query expression at a
+single instant or over a range of time. This can be used to retrieve back
+Aporeto specific metrics for a given namespace. All queries are protected within
+the namespace of the caller.`
+}
+
+func (o *MetricsQuery) String() string {
+
+	return fmt.Sprintf("<%s:%s>", o.Identity().Name, o.Identifier())
+}
+
+// ToSparse returns the sparse version of the model.
+// The returned object will only contain the given fields. No field means entire field set.
+func (o *MetricsQuery) ToSparse(fields ...string) elemental.SparseIdentifiable {
+
+	if len(fields) == 0 {
+		// nolint: goimports
+		return &SparseMetricsQuery{
+			Query: &o.Query,
+			Time:  &o.Time,
+		}
+	}
+
+	sp := &SparseMetricsQuery{}
+	for _, f := range fields {
+		switch f {
+		case "query":
+			sp.Query = &(o.Query)
+		case "time":
+			sp.Time = &(o.Time)
+		}
+	}
+
+	return sp
+}
+
+// Patch apply the non nil value of a *SparseMetricsQuery to the object.
+func (o *MetricsQuery) Patch(sparse elemental.SparseIdentifiable) {
+	if !sparse.Identity().IsEqual(o.Identity()) {
+		panic("cannot patch from a parse with different identity")
+	}
+
+	so := sparse.(*SparseMetricsQuery)
+	if so.Query != nil {
+		o.Query = *so.Query
+	}
+	if so.Time != nil {
+		o.Time = *so.Time
+	}
+}
+
+// DeepCopy returns a deep copy if the MetricsQuery.
+func (o *MetricsQuery) DeepCopy() *MetricsQuery {
+
+	if o == nil {
+		return nil
+	}
+
+	out := &MetricsQuery{}
+	o.DeepCopyInto(out)
+
+	return out
+}
+
+// DeepCopyInto copies the receiver into the given *MetricsQuery.
+func (o *MetricsQuery) DeepCopyInto(out *MetricsQuery) {
+
+	target, err := copystructure.Copy(o)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to deepcopy MetricsQuery: %s", err))
+	}
+
+	*out = *target.(*MetricsQuery)
+}
+
+// Validate valides the current information stored into the structure.
+func (o *MetricsQuery) Validate() error {
+
+	errors := elemental.Errors{}
+	requiredErrors := elemental.Errors{}
+
+	if err := elemental.ValidateRequiredString("query", o.Query); err != nil {
+		requiredErrors = requiredErrors.Append(err)
+	}
+
+	if len(requiredErrors) > 0 {
+		return requiredErrors
+	}
+
+	if len(errors) > 0 {
+		return errors
+	}
+
+	return nil
+}
+
+// SpecificationForAttribute returns the AttributeSpecification for the given attribute name key.
+func (*MetricsQuery) SpecificationForAttribute(name string) elemental.AttributeSpecification {
+
+	if v, ok := MetricsQueryAttributesMap[name]; ok {
+		return v
+	}
+
+	// We could not find it, so let's check on the lower case indexed spec map
+	return MetricsQueryLowerCaseAttributesMap[name]
+}
+
+// AttributeSpecifications returns the full attribute specifications map.
+func (*MetricsQuery) AttributeSpecifications() map[string]elemental.AttributeSpecification {
+
+	return MetricsQueryAttributesMap
+}
+
+// ValueForAttribute returns the value for the given attribute.
+// This is a very advanced function that you should not need but in some
+// very specific use cases.
+func (o *MetricsQuery) ValueForAttribute(name string) interface{} {
+
+	switch name {
+	case "query":
+		return o.Query
+	case "time":
+		return o.Time
+	}
+
+	return nil
+}
+
+// MetricsQueryAttributesMap represents the map of attribute for MetricsQuery.
+var MetricsQueryAttributesMap = map[string]elemental.AttributeSpecification{
+	"Query": {
+		AllowedChoices: []string{},
+		ConvertedName:  "Query",
+		Description:    `Prometheus expression query string.`,
+		Exposed:        true,
+		Name:           "query",
+		Required:       true,
+		Type:           "string",
+	},
+	"Time": {
+		AllowedChoices: []string{},
+		ConvertedName:  "Time",
+		Description:    `Evaluation timestamp <rfc3339 | unix_timestamp>.`,
+		Exposed:        true,
+		Name:           "time",
+		Type:           "string",
+	},
+}
+
+// MetricsQueryLowerCaseAttributesMap represents the map of attribute for MetricsQuery.
+var MetricsQueryLowerCaseAttributesMap = map[string]elemental.AttributeSpecification{
+	"query": {
+		AllowedChoices: []string{},
+		ConvertedName:  "Query",
+		Description:    `Prometheus expression query string.`,
+		Exposed:        true,
+		Name:           "query",
+		Required:       true,
+		Type:           "string",
+	},
+	"time": {
+		AllowedChoices: []string{},
+		ConvertedName:  "Time",
+		Description:    `Evaluation timestamp <rfc3339 | unix_timestamp>.`,
+		Exposed:        true,
+		Name:           "time",
+		Type:           "string",
+	},
+}
+
+// SparseMetricsQueriesList represents a list of SparseMetricsQueries
+type SparseMetricsQueriesList []*SparseMetricsQuery
+
+// Identity returns the identity of the objects in the list.
+func (o SparseMetricsQueriesList) Identity() elemental.Identity {
+
+	return MetricsQueryIdentity
+}
+
+// Copy returns a pointer to a copy the SparseMetricsQueriesList.
+func (o SparseMetricsQueriesList) Copy() elemental.Identifiables {
+
+	copy := append(SparseMetricsQueriesList{}, o...)
+	return &copy
+}
+
+// Append appends the objects to the a new copy of the SparseMetricsQueriesList.
+func (o SparseMetricsQueriesList) Append(objects ...elemental.Identifiable) elemental.Identifiables {
+
+	out := append(SparseMetricsQueriesList{}, o...)
+	for _, obj := range objects {
+		out = append(out, obj.(*SparseMetricsQuery))
+	}
+
+	return out
+}
+
+// List converts the object to an elemental.IdentifiablesList.
+func (o SparseMetricsQueriesList) List() elemental.IdentifiablesList {
+
+	out := make(elemental.IdentifiablesList, len(o))
+	for i := 0; i < len(o); i++ {
+		out[i] = o[i]
+	}
+
+	return out
+}
+
+// DefaultOrder returns the default ordering fields of the content.
+func (o SparseMetricsQueriesList) DefaultOrder() []string {
+
+	return []string{}
+}
+
+// ToPlain returns the SparseMetricsQueriesList converted to MetricsQueriesList.
+func (o SparseMetricsQueriesList) ToPlain() elemental.IdentifiablesList {
+
+	out := make(elemental.IdentifiablesList, len(o))
+	for i := 0; i < len(o); i++ {
+		out[i] = o[i].ToPlain()
+	}
+
+	return out
+}
+
+// Version returns the version of the content.
+func (o SparseMetricsQueriesList) Version() int {
+
+	return 1
+}
+
+// SparseMetricsQuery represents the sparse version of a metricsquery.
+type SparseMetricsQuery struct {
+	// Prometheus expression query string.
+	Query *string `json:"query,omitempty" msgpack:"query,omitempty" bson:"-" mapstructure:"query,omitempty"`
+
+	// Evaluation timestamp <rfc3339 | unix_timestamp>.
+	Time *string `json:"time,omitempty" msgpack:"time,omitempty" bson:"-" mapstructure:"time,omitempty"`
+
+	ModelVersion int `json:"-" msgpack:"-" bson:"_modelversion"`
+}
+
+// NewSparseMetricsQuery returns a new  SparseMetricsQuery.
+func NewSparseMetricsQuery() *SparseMetricsQuery {
+	return &SparseMetricsQuery{}
+}
+
+// Identity returns the Identity of the sparse object.
+func (o *SparseMetricsQuery) Identity() elemental.Identity {
+
+	return MetricsQueryIdentity
+}
+
+// Identifier returns the value of the sparse object's unique identifier.
+func (o *SparseMetricsQuery) Identifier() string {
+
+	return ""
+}
+
+// SetIdentifier sets the value of the sparse object's unique identifier.
+func (o *SparseMetricsQuery) SetIdentifier(id string) {
+
+}
+
+// GetBSON implements the bson marshaling interface.
+// This is used to transparently convert ID to MongoDBID as ObectID.
+func (o *SparseMetricsQuery) GetBSON() (interface{}, error) {
+
+	if o == nil {
+		return nil, nil
+	}
+
+	s := &mongoAttributesSparseMetricsQuery{}
+
+	return s, nil
+}
+
+// SetBSON implements the bson marshaling interface.
+// This is used to transparently convert ID to MongoDBID as ObectID.
+func (o *SparseMetricsQuery) SetBSON(raw bson.Raw) error {
+
+	if o == nil {
+		return nil
+	}
+
+	s := &mongoAttributesSparseMetricsQuery{}
+	if err := raw.Unmarshal(s); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Version returns the hardcoded version of the model.
+func (o *SparseMetricsQuery) Version() int {
+
+	return 1
+}
+
+// ToPlain returns the plain version of the sparse model.
+func (o *SparseMetricsQuery) ToPlain() elemental.PlainIdentifiable {
+
+	out := NewMetricsQuery()
+	if o.Query != nil {
+		out.Query = *o.Query
+	}
+	if o.Time != nil {
+		out.Time = *o.Time
+	}
+
+	return out
+}
+
+// DeepCopy returns a deep copy if the SparseMetricsQuery.
+func (o *SparseMetricsQuery) DeepCopy() *SparseMetricsQuery {
+
+	if o == nil {
+		return nil
+	}
+
+	out := &SparseMetricsQuery{}
+	o.DeepCopyInto(out)
+
+	return out
+}
+
+// DeepCopyInto copies the receiver into the given *SparseMetricsQuery.
+func (o *SparseMetricsQuery) DeepCopyInto(out *SparseMetricsQuery) {
+
+	target, err := copystructure.Copy(o)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to deepcopy SparseMetricsQuery: %s", err))
+	}
+
+	*out = *target.(*SparseMetricsQuery)
+}
+
+type mongoAttributesMetricsQuery struct {
+}
+type mongoAttributesSparseMetricsQuery struct {
+}

--- a/metricsqueryrange.go
+++ b/metricsqueryrange.go
@@ -8,43 +8,43 @@ import (
 	"go.aporeto.io/elemental"
 )
 
-// MetricsIdentity represents the Identity of the object.
-var MetricsIdentity = elemental.Identity{
-	Name:     "metrics",
-	Category: "metrics",
+// MetricsQueryRangeIdentity represents the Identity of the object.
+var MetricsQueryRangeIdentity = elemental.Identity{
+	Name:     "metricsqueryrange",
+	Category: "metricsqueryrange",
 	Package:  "jenova",
 	Private:  false,
 }
 
-// MetricsList represents a list of Metrics
-type MetricsList []*Metrics
+// MetricsQueryRangesList represents a list of MetricsQueryRanges
+type MetricsQueryRangesList []*MetricsQueryRange
 
 // Identity returns the identity of the objects in the list.
-func (o MetricsList) Identity() elemental.Identity {
+func (o MetricsQueryRangesList) Identity() elemental.Identity {
 
-	return MetricsIdentity
+	return MetricsQueryRangeIdentity
 }
 
-// Copy returns a pointer to a copy the MetricsList.
-func (o MetricsList) Copy() elemental.Identifiables {
+// Copy returns a pointer to a copy the MetricsQueryRangesList.
+func (o MetricsQueryRangesList) Copy() elemental.Identifiables {
 
-	copy := append(MetricsList{}, o...)
+	copy := append(MetricsQueryRangesList{}, o...)
 	return &copy
 }
 
-// Append appends the objects to the a new copy of the MetricsList.
-func (o MetricsList) Append(objects ...elemental.Identifiable) elemental.Identifiables {
+// Append appends the objects to the a new copy of the MetricsQueryRangesList.
+func (o MetricsQueryRangesList) Append(objects ...elemental.Identifiable) elemental.Identifiables {
 
-	out := append(MetricsList{}, o...)
+	out := append(MetricsQueryRangesList{}, o...)
 	for _, obj := range objects {
-		out = append(out, obj.(*Metrics))
+		out = append(out, obj.(*MetricsQueryRange))
 	}
 
 	return out
 }
 
 // List converts the object to an elemental.IdentifiablesList.
-func (o MetricsList) List() elemental.IdentifiablesList {
+func (o MetricsQueryRangesList) List() elemental.IdentifiablesList {
 
 	out := make(elemental.IdentifiablesList, len(o))
 	for i := 0; i < len(o); i++ {
@@ -55,35 +55,35 @@ func (o MetricsList) List() elemental.IdentifiablesList {
 }
 
 // DefaultOrder returns the default ordering fields of the content.
-func (o MetricsList) DefaultOrder() []string {
+func (o MetricsQueryRangesList) DefaultOrder() []string {
 
 	return []string{}
 }
 
-// ToSparse returns the MetricsList converted to SparseMetricsList.
+// ToSparse returns the MetricsQueryRangesList converted to SparseMetricsQueryRangesList.
 // Objects in the list will only contain the given fields. No field means entire field set.
-func (o MetricsList) ToSparse(fields ...string) elemental.Identifiables {
+func (o MetricsQueryRangesList) ToSparse(fields ...string) elemental.Identifiables {
 
-	out := make(SparseMetricsList, len(o))
+	out := make(SparseMetricsQueryRangesList, len(o))
 	for i := 0; i < len(o); i++ {
-		out[i] = o[i].ToSparse(fields...).(*SparseMetrics)
+		out[i] = o[i].ToSparse(fields...).(*SparseMetricsQueryRange)
 	}
 
 	return out
 }
 
 // Version returns the version of the content.
-func (o MetricsList) Version() int {
+func (o MetricsQueryRangesList) Version() int {
 
 	return 1
 }
 
-// Metrics represents the model of a metrics
-type Metrics struct {
+// MetricsQueryRange represents the model of a metricsqueryrange
+type MetricsQueryRange struct {
 	// End timestamp <rfc3339 | unix_timestamp>.
 	End string `json:"end" msgpack:"end" bson:"-" mapstructure:"end,omitempty"`
 
-	// Contains the remote `POST` payload.
+	// Prometheus expression query string.
 	Query string `json:"query" msgpack:"query" bson:"-" mapstructure:"query,omitempty"`
 
 	// Start timestamp <rfc3339 | unix_timestamp>.
@@ -95,53 +95,53 @@ type Metrics struct {
 	ModelVersion int `json:"-" msgpack:"-" bson:"_modelversion"`
 }
 
-// NewMetrics returns a new *Metrics
-func NewMetrics() *Metrics {
+// NewMetricsQueryRange returns a new *MetricsQueryRange
+func NewMetricsQueryRange() *MetricsQueryRange {
 
-	return &Metrics{
+	return &MetricsQueryRange{
 		ModelVersion: 1,
 	}
 }
 
 // Identity returns the Identity of the object.
-func (o *Metrics) Identity() elemental.Identity {
+func (o *MetricsQueryRange) Identity() elemental.Identity {
 
-	return MetricsIdentity
+	return MetricsQueryRangeIdentity
 }
 
 // Identifier returns the value of the object's unique identifier.
-func (o *Metrics) Identifier() string {
+func (o *MetricsQueryRange) Identifier() string {
 
 	return ""
 }
 
 // SetIdentifier sets the value of the object's unique identifier.
-func (o *Metrics) SetIdentifier(id string) {
+func (o *MetricsQueryRange) SetIdentifier(id string) {
 
 }
 
 // GetBSON implements the bson marshaling interface.
 // This is used to transparently convert ID to MongoDBID as ObectID.
-func (o *Metrics) GetBSON() (interface{}, error) {
+func (o *MetricsQueryRange) GetBSON() (interface{}, error) {
 
 	if o == nil {
 		return nil, nil
 	}
 
-	s := &mongoAttributesMetrics{}
+	s := &mongoAttributesMetricsQueryRange{}
 
 	return s, nil
 }
 
 // SetBSON implements the bson marshaling interface.
 // This is used to transparently convert ID to MongoDBID as ObectID.
-func (o *Metrics) SetBSON(raw bson.Raw) error {
+func (o *MetricsQueryRange) SetBSON(raw bson.Raw) error {
 
 	if o == nil {
 		return nil
 	}
 
-	s := &mongoAttributesMetrics{}
+	s := &mongoAttributesMetricsQueryRange{}
 	if err := raw.Unmarshal(s); err != nil {
 		return err
 	}
@@ -150,43 +150,43 @@ func (o *Metrics) SetBSON(raw bson.Raw) error {
 }
 
 // Version returns the hardcoded version of the model.
-func (o *Metrics) Version() int {
+func (o *MetricsQueryRange) Version() int {
 
 	return 1
 }
 
 // BleveType implements the bleve.Classifier Interface.
-func (o *Metrics) BleveType() string {
+func (o *MetricsQueryRange) BleveType() string {
 
-	return "metrics"
+	return "metricsqueryrange"
 }
 
 // DefaultOrder returns the list of default ordering fields.
-func (o *Metrics) DefaultOrder() []string {
+func (o *MetricsQueryRange) DefaultOrder() []string {
 
 	return []string{}
 }
 
 // Doc returns the documentation for the object
-func (o *Metrics) Doc() string {
+func (o *MetricsQueryRange) Doc() string {
 
 	return `Prometheus compatible endpoint to evaluate an expression query over a range of
 time. This can be used to retrieve back Aporeto specific metrics for a given
 namespace. All queries are protected within the namespace of the caller.`
 }
 
-func (o *Metrics) String() string {
+func (o *MetricsQueryRange) String() string {
 
 	return fmt.Sprintf("<%s:%s>", o.Identity().Name, o.Identifier())
 }
 
 // ToSparse returns the sparse version of the model.
 // The returned object will only contain the given fields. No field means entire field set.
-func (o *Metrics) ToSparse(fields ...string) elemental.SparseIdentifiable {
+func (o *MetricsQueryRange) ToSparse(fields ...string) elemental.SparseIdentifiable {
 
 	if len(fields) == 0 {
 		// nolint: goimports
-		return &SparseMetrics{
+		return &SparseMetricsQueryRange{
 			End:   &o.End,
 			Query: &o.Query,
 			Start: &o.Start,
@@ -194,7 +194,7 @@ func (o *Metrics) ToSparse(fields ...string) elemental.SparseIdentifiable {
 		}
 	}
 
-	sp := &SparseMetrics{}
+	sp := &SparseMetricsQueryRange{}
 	for _, f := range fields {
 		switch f {
 		case "end":
@@ -211,13 +211,13 @@ func (o *Metrics) ToSparse(fields ...string) elemental.SparseIdentifiable {
 	return sp
 }
 
-// Patch apply the non nil value of a *SparseMetrics to the object.
-func (o *Metrics) Patch(sparse elemental.SparseIdentifiable) {
+// Patch apply the non nil value of a *SparseMetricsQueryRange to the object.
+func (o *MetricsQueryRange) Patch(sparse elemental.SparseIdentifiable) {
 	if !sparse.Identity().IsEqual(o.Identity()) {
 		panic("cannot patch from a parse with different identity")
 	}
 
-	so := sparse.(*SparseMetrics)
+	so := sparse.(*SparseMetricsQueryRange)
 	if so.End != nil {
 		o.End = *so.End
 	}
@@ -232,32 +232,32 @@ func (o *Metrics) Patch(sparse elemental.SparseIdentifiable) {
 	}
 }
 
-// DeepCopy returns a deep copy if the Metrics.
-func (o *Metrics) DeepCopy() *Metrics {
+// DeepCopy returns a deep copy if the MetricsQueryRange.
+func (o *MetricsQueryRange) DeepCopy() *MetricsQueryRange {
 
 	if o == nil {
 		return nil
 	}
 
-	out := &Metrics{}
+	out := &MetricsQueryRange{}
 	o.DeepCopyInto(out)
 
 	return out
 }
 
-// DeepCopyInto copies the receiver into the given *Metrics.
-func (o *Metrics) DeepCopyInto(out *Metrics) {
+// DeepCopyInto copies the receiver into the given *MetricsQueryRange.
+func (o *MetricsQueryRange) DeepCopyInto(out *MetricsQueryRange) {
 
 	target, err := copystructure.Copy(o)
 	if err != nil {
-		panic(fmt.Sprintf("Unable to deepcopy Metrics: %s", err))
+		panic(fmt.Sprintf("Unable to deepcopy MetricsQueryRange: %s", err))
 	}
 
-	*out = *target.(*Metrics)
+	*out = *target.(*MetricsQueryRange)
 }
 
 // Validate valides the current information stored into the structure.
-func (o *Metrics) Validate() error {
+func (o *MetricsQueryRange) Validate() error {
 
 	errors := elemental.Errors{}
 	requiredErrors := elemental.Errors{}
@@ -278,26 +278,26 @@ func (o *Metrics) Validate() error {
 }
 
 // SpecificationForAttribute returns the AttributeSpecification for the given attribute name key.
-func (*Metrics) SpecificationForAttribute(name string) elemental.AttributeSpecification {
+func (*MetricsQueryRange) SpecificationForAttribute(name string) elemental.AttributeSpecification {
 
-	if v, ok := MetricsAttributesMap[name]; ok {
+	if v, ok := MetricsQueryRangeAttributesMap[name]; ok {
 		return v
 	}
 
 	// We could not find it, so let's check on the lower case indexed spec map
-	return MetricsLowerCaseAttributesMap[name]
+	return MetricsQueryRangeLowerCaseAttributesMap[name]
 }
 
 // AttributeSpecifications returns the full attribute specifications map.
-func (*Metrics) AttributeSpecifications() map[string]elemental.AttributeSpecification {
+func (*MetricsQueryRange) AttributeSpecifications() map[string]elemental.AttributeSpecification {
 
-	return MetricsAttributesMap
+	return MetricsQueryRangeAttributesMap
 }
 
 // ValueForAttribute returns the value for the given attribute.
 // This is a very advanced function that you should not need but in some
 // very specific use cases.
-func (o *Metrics) ValueForAttribute(name string) interface{} {
+func (o *MetricsQueryRange) ValueForAttribute(name string) interface{} {
 
 	switch name {
 	case "end":
@@ -313,8 +313,8 @@ func (o *Metrics) ValueForAttribute(name string) interface{} {
 	return nil
 }
 
-// MetricsAttributesMap represents the map of attribute for Metrics.
-var MetricsAttributesMap = map[string]elemental.AttributeSpecification{
+// MetricsQueryRangeAttributesMap represents the map of attribute for MetricsQueryRange.
+var MetricsQueryRangeAttributesMap = map[string]elemental.AttributeSpecification{
 	"End": {
 		AllowedChoices: []string{},
 		ConvertedName:  "End",
@@ -326,7 +326,7 @@ var MetricsAttributesMap = map[string]elemental.AttributeSpecification{
 	"Query": {
 		AllowedChoices: []string{},
 		ConvertedName:  "Query",
-		Description:    `Contains the remote ` + "`" + `POST` + "`" + ` payload.`,
+		Description:    `Prometheus expression query string.`,
 		Exposed:        true,
 		Name:           "query",
 		Required:       true,
@@ -350,8 +350,8 @@ var MetricsAttributesMap = map[string]elemental.AttributeSpecification{
 	},
 }
 
-// MetricsLowerCaseAttributesMap represents the map of attribute for Metrics.
-var MetricsLowerCaseAttributesMap = map[string]elemental.AttributeSpecification{
+// MetricsQueryRangeLowerCaseAttributesMap represents the map of attribute for MetricsQueryRange.
+var MetricsQueryRangeLowerCaseAttributesMap = map[string]elemental.AttributeSpecification{
 	"end": {
 		AllowedChoices: []string{},
 		ConvertedName:  "End",
@@ -363,7 +363,7 @@ var MetricsLowerCaseAttributesMap = map[string]elemental.AttributeSpecification{
 	"query": {
 		AllowedChoices: []string{},
 		ConvertedName:  "Query",
-		Description:    `Contains the remote ` + "`" + `POST` + "`" + ` payload.`,
+		Description:    `Prometheus expression query string.`,
 		Exposed:        true,
 		Name:           "query",
 		Required:       true,
@@ -387,35 +387,35 @@ var MetricsLowerCaseAttributesMap = map[string]elemental.AttributeSpecification{
 	},
 }
 
-// SparseMetricsList represents a list of SparseMetrics
-type SparseMetricsList []*SparseMetrics
+// SparseMetricsQueryRangesList represents a list of SparseMetricsQueryRanges
+type SparseMetricsQueryRangesList []*SparseMetricsQueryRange
 
 // Identity returns the identity of the objects in the list.
-func (o SparseMetricsList) Identity() elemental.Identity {
+func (o SparseMetricsQueryRangesList) Identity() elemental.Identity {
 
-	return MetricsIdentity
+	return MetricsQueryRangeIdentity
 }
 
-// Copy returns a pointer to a copy the SparseMetricsList.
-func (o SparseMetricsList) Copy() elemental.Identifiables {
+// Copy returns a pointer to a copy the SparseMetricsQueryRangesList.
+func (o SparseMetricsQueryRangesList) Copy() elemental.Identifiables {
 
-	copy := append(SparseMetricsList{}, o...)
+	copy := append(SparseMetricsQueryRangesList{}, o...)
 	return &copy
 }
 
-// Append appends the objects to the a new copy of the SparseMetricsList.
-func (o SparseMetricsList) Append(objects ...elemental.Identifiable) elemental.Identifiables {
+// Append appends the objects to the a new copy of the SparseMetricsQueryRangesList.
+func (o SparseMetricsQueryRangesList) Append(objects ...elemental.Identifiable) elemental.Identifiables {
 
-	out := append(SparseMetricsList{}, o...)
+	out := append(SparseMetricsQueryRangesList{}, o...)
 	for _, obj := range objects {
-		out = append(out, obj.(*SparseMetrics))
+		out = append(out, obj.(*SparseMetricsQueryRange))
 	}
 
 	return out
 }
 
 // List converts the object to an elemental.IdentifiablesList.
-func (o SparseMetricsList) List() elemental.IdentifiablesList {
+func (o SparseMetricsQueryRangesList) List() elemental.IdentifiablesList {
 
 	out := make(elemental.IdentifiablesList, len(o))
 	for i := 0; i < len(o); i++ {
@@ -426,13 +426,13 @@ func (o SparseMetricsList) List() elemental.IdentifiablesList {
 }
 
 // DefaultOrder returns the default ordering fields of the content.
-func (o SparseMetricsList) DefaultOrder() []string {
+func (o SparseMetricsQueryRangesList) DefaultOrder() []string {
 
 	return []string{}
 }
 
-// ToPlain returns the SparseMetricsList converted to MetricsList.
-func (o SparseMetricsList) ToPlain() elemental.IdentifiablesList {
+// ToPlain returns the SparseMetricsQueryRangesList converted to MetricsQueryRangesList.
+func (o SparseMetricsQueryRangesList) ToPlain() elemental.IdentifiablesList {
 
 	out := make(elemental.IdentifiablesList, len(o))
 	for i := 0; i < len(o); i++ {
@@ -443,17 +443,17 @@ func (o SparseMetricsList) ToPlain() elemental.IdentifiablesList {
 }
 
 // Version returns the version of the content.
-func (o SparseMetricsList) Version() int {
+func (o SparseMetricsQueryRangesList) Version() int {
 
 	return 1
 }
 
-// SparseMetrics represents the sparse version of a metrics.
-type SparseMetrics struct {
+// SparseMetricsQueryRange represents the sparse version of a metricsqueryrange.
+type SparseMetricsQueryRange struct {
 	// End timestamp <rfc3339 | unix_timestamp>.
 	End *string `json:"end,omitempty" msgpack:"end,omitempty" bson:"-" mapstructure:"end,omitempty"`
 
-	// Contains the remote `POST` payload.
+	// Prometheus expression query string.
 	Query *string `json:"query,omitempty" msgpack:"query,omitempty" bson:"-" mapstructure:"query,omitempty"`
 
 	// Start timestamp <rfc3339 | unix_timestamp>.
@@ -465,50 +465,50 @@ type SparseMetrics struct {
 	ModelVersion int `json:"-" msgpack:"-" bson:"_modelversion"`
 }
 
-// NewSparseMetrics returns a new  SparseMetrics.
-func NewSparseMetrics() *SparseMetrics {
-	return &SparseMetrics{}
+// NewSparseMetricsQueryRange returns a new  SparseMetricsQueryRange.
+func NewSparseMetricsQueryRange() *SparseMetricsQueryRange {
+	return &SparseMetricsQueryRange{}
 }
 
 // Identity returns the Identity of the sparse object.
-func (o *SparseMetrics) Identity() elemental.Identity {
+func (o *SparseMetricsQueryRange) Identity() elemental.Identity {
 
-	return MetricsIdentity
+	return MetricsQueryRangeIdentity
 }
 
 // Identifier returns the value of the sparse object's unique identifier.
-func (o *SparseMetrics) Identifier() string {
+func (o *SparseMetricsQueryRange) Identifier() string {
 
 	return ""
 }
 
 // SetIdentifier sets the value of the sparse object's unique identifier.
-func (o *SparseMetrics) SetIdentifier(id string) {
+func (o *SparseMetricsQueryRange) SetIdentifier(id string) {
 
 }
 
 // GetBSON implements the bson marshaling interface.
 // This is used to transparently convert ID to MongoDBID as ObectID.
-func (o *SparseMetrics) GetBSON() (interface{}, error) {
+func (o *SparseMetricsQueryRange) GetBSON() (interface{}, error) {
 
 	if o == nil {
 		return nil, nil
 	}
 
-	s := &mongoAttributesSparseMetrics{}
+	s := &mongoAttributesSparseMetricsQueryRange{}
 
 	return s, nil
 }
 
 // SetBSON implements the bson marshaling interface.
 // This is used to transparently convert ID to MongoDBID as ObectID.
-func (o *SparseMetrics) SetBSON(raw bson.Raw) error {
+func (o *SparseMetricsQueryRange) SetBSON(raw bson.Raw) error {
 
 	if o == nil {
 		return nil
 	}
 
-	s := &mongoAttributesSparseMetrics{}
+	s := &mongoAttributesSparseMetricsQueryRange{}
 	if err := raw.Unmarshal(s); err != nil {
 		return err
 	}
@@ -517,15 +517,15 @@ func (o *SparseMetrics) SetBSON(raw bson.Raw) error {
 }
 
 // Version returns the hardcoded version of the model.
-func (o *SparseMetrics) Version() int {
+func (o *SparseMetricsQueryRange) Version() int {
 
 	return 1
 }
 
 // ToPlain returns the plain version of the sparse model.
-func (o *SparseMetrics) ToPlain() elemental.PlainIdentifiable {
+func (o *SparseMetricsQueryRange) ToPlain() elemental.PlainIdentifiable {
 
-	out := NewMetrics()
+	out := NewMetricsQueryRange()
 	if o.End != nil {
 		out.End = *o.End
 	}
@@ -542,31 +542,31 @@ func (o *SparseMetrics) ToPlain() elemental.PlainIdentifiable {
 	return out
 }
 
-// DeepCopy returns a deep copy if the SparseMetrics.
-func (o *SparseMetrics) DeepCopy() *SparseMetrics {
+// DeepCopy returns a deep copy if the SparseMetricsQueryRange.
+func (o *SparseMetricsQueryRange) DeepCopy() *SparseMetricsQueryRange {
 
 	if o == nil {
 		return nil
 	}
 
-	out := &SparseMetrics{}
+	out := &SparseMetricsQueryRange{}
 	o.DeepCopyInto(out)
 
 	return out
 }
 
-// DeepCopyInto copies the receiver into the given *SparseMetrics.
-func (o *SparseMetrics) DeepCopyInto(out *SparseMetrics) {
+// DeepCopyInto copies the receiver into the given *SparseMetricsQueryRange.
+func (o *SparseMetricsQueryRange) DeepCopyInto(out *SparseMetricsQueryRange) {
 
 	target, err := copystructure.Copy(o)
 	if err != nil {
-		panic(fmt.Sprintf("Unable to deepcopy SparseMetrics: %s", err))
+		panic(fmt.Sprintf("Unable to deepcopy SparseMetricsQueryRange: %s", err))
 	}
 
-	*out = *target.(*SparseMetrics)
+	*out = *target.(*SparseMetricsQueryRange)
 }
 
-type mongoAttributesMetrics struct {
+type mongoAttributesMetricsQueryRange struct {
 }
-type mongoAttributesSparseMetrics struct {
+type mongoAttributesSparseMetricsQueryRange struct {
 }

--- a/relationships_registry.go
+++ b/relationships_registry.go
@@ -2802,7 +2802,59 @@ func init() {
 		},
 	}
 
-	relationshipsRegistry[MetricsIdentity] = &elemental.Relationship{
+	relationshipsRegistry[MetricsQueryIdentity] = &elemental.Relationship{
+		Create: map[string]*elemental.RelationshipInfo{
+			"root": {},
+		},
+		RetrieveMany: map[string]*elemental.RelationshipInfo{
+			"root": {
+				RequiredParameters: elemental.NewParametersRequirement(
+					[][][]string{
+						{
+							{
+								"query",
+							},
+						},
+					},
+				),
+				Parameters: []elemental.ParameterDefinition{
+					{
+						Name: "query",
+						Type: "string",
+					},
+					{
+						Name: "time",
+						Type: "string",
+					},
+				},
+			},
+		},
+		Info: map[string]*elemental.RelationshipInfo{
+			"root": {
+				RequiredParameters: elemental.NewParametersRequirement(
+					[][][]string{
+						{
+							{
+								"query",
+							},
+						},
+					},
+				),
+				Parameters: []elemental.ParameterDefinition{
+					{
+						Name: "query",
+						Type: "string",
+					},
+					{
+						Name: "time",
+						Type: "string",
+					},
+				},
+			},
+		},
+	}
+
+	relationshipsRegistry[MetricsQueryRangeIdentity] = &elemental.Relationship{
 		Create: map[string]*elemental.RelationshipInfo{
 			"root": {},
 		},

--- a/specs/metricsquery.spec
+++ b/specs/metricsquery.spec
@@ -1,0 +1,30 @@
+# Model
+model:
+  rest_name: metricsquery
+  resource_name: metricsquery
+  entity_name: MetricsQuery
+  package: jenova
+  group: visualization/metrics
+  description: |-
+    Prometheus compatible endpoint to evaluate a Prometheus query expression at a
+    single instant or over a range of time. This can be used to retrieve back
+    Aporeto specific metrics for a given namespace. All queries are protected within
+    the namespace of the caller.
+  aliases:
+  - mq
+
+# Attributes
+attributes:
+  v1:
+  - name: query
+    description: Prometheus expression query string.
+    type: string
+    exposed: true
+    required: true
+    example_value: flows{namespace=~"/mycompany.*"}
+
+  - name: time
+    description: Evaluation timestamp <rfc3339 | unix_timestamp>.
+    type: string
+    exposed: true
+    example_value: "2015-07-01T20:11:00.781Z"

--- a/specs/metricsqueryrange.spec
+++ b/specs/metricsqueryrange.spec
@@ -35,7 +35,8 @@ attributes:
     example_value: "2015-07-01T20:11:00.781Z"
 
   - name: step
-    description: Query resolution step width in duration format or float number of seconds.
+    description: Query resolution step width in duration format or float number of
+      seconds.
     type: string
     exposed: true
     example_value: 15s

--- a/specs/metricsqueryrange.spec
+++ b/specs/metricsqueryrange.spec
@@ -1,8 +1,8 @@
 # Model
 model:
-  rest_name: metrics
-  resource_name: metrics
-  entity_name: Metrics
+  rest_name: metricsqueryrange
+  resource_name: metricsqueryrange
+  entity_name: MetricsQueryRange
   package: jenova
   group: visualization/metrics
   description: |-
@@ -10,7 +10,7 @@ model:
     time. This can be used to retrieve back Aporeto specific metrics for a given
     namespace. All queries are protected within the namespace of the caller.
   aliases:
-  - mq
+  - mqr
 
 # Attributes
 attributes:
@@ -22,7 +22,7 @@ attributes:
     example_value: "2015-07-01T20:11:00.781Z"
 
   - name: query
-    description: Contains the remote `POST` payload.
+    description: Prometheus expression query string.
     type: string
     exposed: true
     required: true
@@ -35,8 +35,7 @@ attributes:
     example_value: "2015-07-01T20:11:00.781Z"
 
   - name: step
-    description: Query resolution step width in duration format or float number of
-      seconds.
+    description: Query resolution step width in duration format or float number of seconds.
     type: string
     exposed: true
     example_value: 15s

--- a/specs/root.spec
+++ b/specs/root.spec
@@ -143,8 +143,7 @@ relations:
 
 - rest_name: authn
   get:
-    description: Verify the validity of a token. This is deprecated. You should use
-      Create.
+    description: Verify the validity of a token. This is deprecated. You should use Create.
     parameters:
       entries:
       - name: token
@@ -259,8 +258,7 @@ relations:
     description: (Deprecated) Returns the list of discovery modes.
     deprecated: true
   create:
-    description: (Deprecated) Deploy the discovery mode assets onto the specified
-      namespace.
+    description: (Deprecated) Deploy the discovery mode assets onto the specified namespace.
     deprecated: true
 
 - rest_name: dnslookupreport
@@ -385,10 +383,7 @@ relations:
     parameters:
       entries:
       - name: quiet
-        description: If set to true, the health check endpoint will not return data
-          but will return 200 OK if everything is fine or 218 if the controller is
-          not operational. This is useful when you want to use the health check endpoint
-          as a load balancer health check.
+        description: If set to true, the health check endpoint will not return data but will return 200 OK if everything is fine or 218 if the controller is not operational. This is useful when you want to use the health check endpoint as a load balancer health check.
         type: boolean
 
 - rest_name: hit
@@ -557,8 +552,7 @@ relations:
     parameters:
       entries:
       - name: asCookie
-        description: If set to true, the token will be delivered in a secure cookie,
-          and not in the response body.
+        description: If set to true, the token will be delivered in a secure cookie, and not in the response body.
         type: boolean
 
       - name: token
@@ -597,7 +591,35 @@ relations:
   create:
     description: Creates a new message.
 
-- rest_name: metrics
+- rest_name: metricsquery
+  get:
+    description: |-
+      Prometheus compatible endpoint to evaluate a Prometheus query expression at a
+      single instant or over a range of time.
+    parameters:
+      required:
+      - - - query
+      entries:
+      - name: query
+        description: Prometheus expression query string.
+        type: string
+        example_value: flows{namespace=~"/mycompany.*"}
+
+      - name: time
+        description: Evaluation timestamp <rfc3339 | unix_timestamp>.
+        type: string
+        example_value: "2015-07-01T20:10:30.781Z"
+  create:
+    description: |-
+      Prometheus compatible endpoint to evaluate a Prometheus query expression at a
+      single instant or over a range of time.
+      This has the same behavior as the GET request, however it is useful when
+      specifying a large query that may breach server-side URL character limits. In
+      such a case, you can URL-encode the parameters that would be used for a GET
+      request directly in the request body by using the POST method and Content-Type:
+      application/x-www-form-urlencoded header.
+
+- rest_name: metricsqueryrange
   get:
     description: |-
       Evaluates an expression query over a range of time returning a "matrix" result
@@ -622,8 +644,7 @@ relations:
         example_value: "2015-07-01T20:10:30.781Z"
 
       - name: step
-        description: Query resolution step width in duration format or float number
-          of seconds.
+        description: Query resolution step width in duration format or float number of seconds.
         type: string
         example_value: 15s
   create:
@@ -643,8 +664,7 @@ relations:
     parameters:
       entries:
       - name: authorized
-        description: Returns all namespaces the token bearer has the right to read.
-          If set, other parameters like `recursive` or `q` will have no effect.
+        description: Returns all namespaces the token bearer has the right to read. If set, other parameters like `recursive` or `q` will have no effect.
         type: boolean
   create:
     description: Creates a new namespace.
@@ -788,8 +808,7 @@ relations:
     parameters:
       entries:
       - name: remaining
-        description: Makes the system count how many object are left available in
-          the quota.
+        description: Makes the system count how many object are left available in the quota.
         type: boolean
 
 - rest_name: quotapolicy

--- a/specs/root.spec
+++ b/specs/root.spec
@@ -143,7 +143,8 @@ relations:
 
 - rest_name: authn
   get:
-    description: Verify the validity of a token. This is deprecated. You should use Create.
+    description: Verify the validity of a token. This is deprecated. You should use
+      Create.
     parameters:
       entries:
       - name: token
@@ -258,7 +259,8 @@ relations:
     description: (Deprecated) Returns the list of discovery modes.
     deprecated: true
   create:
-    description: (Deprecated) Deploy the discovery mode assets onto the specified namespace.
+    description: (Deprecated) Deploy the discovery mode assets onto the specified
+      namespace.
     deprecated: true
 
 - rest_name: dnslookupreport
@@ -383,7 +385,10 @@ relations:
     parameters:
       entries:
       - name: quiet
-        description: If set to true, the health check endpoint will not return data but will return 200 OK if everything is fine or 218 if the controller is not operational. This is useful when you want to use the health check endpoint as a load balancer health check.
+        description: If set to true, the health check endpoint will not return data
+          but will return 200 OK if everything is fine or 218 if the controller is
+          not operational. This is useful when you want to use the health check endpoint
+          as a load balancer health check.
         type: boolean
 
 - rest_name: hit
@@ -552,7 +557,8 @@ relations:
     parameters:
       entries:
       - name: asCookie
-        description: If set to true, the token will be delivered in a secure cookie, and not in the response body.
+        description: If set to true, the token will be delivered in a secure cookie,
+          and not in the response body.
         type: boolean
 
       - name: token
@@ -644,7 +650,8 @@ relations:
         example_value: "2015-07-01T20:10:30.781Z"
 
       - name: step
-        description: Query resolution step width in duration format or float number of seconds.
+        description: Query resolution step width in duration format or float number
+          of seconds.
         type: string
         example_value: 15s
   create:
@@ -664,7 +671,8 @@ relations:
     parameters:
       entries:
       - name: authorized
-        description: Returns all namespaces the token bearer has the right to read. If set, other parameters like `recursive` or `q` will have no effect.
+        description: Returns all namespaces the token bearer has the right to read.
+          If set, other parameters like `recursive` or `q` will have no effect.
         type: boolean
   create:
     description: Creates a new namespace.
@@ -808,7 +816,8 @@ relations:
     parameters:
       entries:
       - name: remaining
-        description: Makes the system count how many object are left available in the quota.
+        description: Makes the system count how many object are left available in
+          the quota.
         type: boolean
 
 - rest_name: quotapolicy


### PR DESCRIPTION
This PR exposes the VM `/api/v1/query` endpoint so clients can make "[instant queries](https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries)" and renames the APIs as follows:

1. `[GET|POST] /metricsquery` _(proxy API to vm's /api/v1/query endpoint)_
2. `[GET|POST] /metricsqueryrange` _(proxy API to vm's /api/v1/query_range endpoint)_
