### PR TITLE
Restricting the name of the Ruleset object to be 16 characters.

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -5474,7 +5474,7 @@ Console.
 Under some advanced scenarios you may wish to set this to `true`, such as to
 save space or improve performance.
 
-##### `name` [`max_length=32`]
+##### `name` [`max_length=16`]
 
 Type: `string`
 

--- a/networkrule.go
+++ b/networkrule.go
@@ -142,7 +142,7 @@ func (o *NetworkRule) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateMaximumLength("name", o.Name, 32, false); err != nil {
+	if err := elemental.ValidateMaximumLength("name", o.Name, 16, false); err != nil {
 		errors = errors.Append(err)
 	}
 

--- a/specs/+networkrule.spec
+++ b/specs/+networkrule.spec
@@ -38,7 +38,7 @@ attributes:
     description: A user defined name to keep track of the rule in the reporting.
     type: string
     exposed: true
-    max_length: 32
+    max_length: 16
     omit_empty: true
 
   - name: networks


### PR DESCRIPTION
## Description

CNS-1029 - Limit the ruleset name to 16 characters

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.

@t00f @ericrpowers Can you please help with the review.
