### PR TITLE
Update: Make service ports optional for external networks

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -12826,7 +12826,7 @@ Type: `boolean`
 
 Defines if the object is protected.
 
-##### `servicePorts` [`required`]
+##### `servicePorts`
 
 Type: `[]string`
 

--- a/externalnetwork.go
+++ b/externalnetwork.go
@@ -730,10 +730,6 @@ func (o *ExternalNetwork) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateRequiredExternal("servicePorts", o.ServicePorts); err != nil {
-		requiredErrors = requiredErrors.Append(err)
-	}
-
 	if err := ValidateServicePorts("servicePorts", o.ServicePorts); err != nil {
 		errors = errors.Append(err)
 	}
@@ -1039,7 +1035,6 @@ with the '@' prefix, and should only be used by external systems.`,
 		Description:    `List of protocol/ports ` + "`" + `(tcp/80)` + "`" + ` or ` + "`" + `(udp/80:100)` + "`" + `.`,
 		Exposed:        true,
 		Name:           "servicePorts",
-		Required:       true,
 		Stored:         true,
 		SubType:        "string",
 		Type:           "list",
@@ -1330,7 +1325,6 @@ with the '@' prefix, and should only be used by external systems.`,
 		Description:    `List of protocol/ports ` + "`" + `(tcp/80)` + "`" + ` or ` + "`" + `(udp/80:100)` + "`" + `.`,
 		Exposed:        true,
 		Name:           "servicePorts",
-		Required:       true,
 		Stored:         true,
 		SubType:        "string",
 		Type:           "list",

--- a/specs/externalnetwork.spec
+++ b/specs/externalnetwork.spec
@@ -65,7 +65,6 @@ attributes:
     exposed: true
     subtype: string
     stored: true
-    required: true
     example_value:
     - tcp/80
     - udp/80:100


### PR DESCRIPTION
#### Description
As we transition to v2 policy renderer, we will start to drop support for external networks. The first step is that we migrated all service ports from related external networks to network rule set policies, so this attribute is no longer applicable. To avoid bad user experience, we are now going to only allow creating external networks without service ports OR allow existing external networks to have their service ports unchanged or emptied on updates.