### PR TITLE
CNS-1554: add 'namespace' property to CounterReport & ConnectionExceptionReport + misc.

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -63,6 +63,7 @@ collectionID
 CollectionID
 ComplianceIssue
 ConnectionExceptionReport
+ConnectionExceptionReports
 containerd
 ContainerImage
 CounterReports

--- a/connectionexceptionreport.go
+++ b/connectionexceptionreport.go
@@ -138,6 +138,9 @@ type ConnectionExceptionReport struct {
 	// Internal property maintaining migrations information.
 	MigrationsLog map[string]string `json:"-" msgpack:"-" bson:"migrationslog,omitempty" mapstructure:"-,omitempty"`
 
+	// Namespace of the processing unit encountered this exception.
+	Namespace string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"p,omitempty" mapstructure:"namespace,omitempty"`
+
 	// ID of the processing unit encountered this exception.
 	ProcessingUnitID string `json:"processingUnitID,omitempty" msgpack:"processingUnitID,omitempty" bson:"g,omitempty" mapstructure:"processingUnitID,omitempty"`
 
@@ -180,8 +183,8 @@ func NewConnectionExceptionReport() *ConnectionExceptionReport {
 
 	return &ConnectionExceptionReport{
 		ModelVersion:  1,
-		MigrationsLog: map[string]string{},
 		ServiceType:   ConnectionExceptionReportServiceTypeL3,
+		MigrationsLog: map[string]string{},
 	}
 }
 
@@ -223,6 +226,7 @@ func (o *ConnectionExceptionReport) GetBSON() (interface{}, error) {
 	s.EnforcerID = o.EnforcerID
 	s.EnforcerNamespace = o.EnforcerNamespace
 	s.MigrationsLog = o.MigrationsLog
+	s.Namespace = o.Namespace
 	s.ProcessingUnitID = o.ProcessingUnitID
 	s.ProcessingUnitNamespace = o.ProcessingUnitNamespace
 	s.Protocol = o.Protocol
@@ -259,6 +263,7 @@ func (o *ConnectionExceptionReport) SetBSON(raw bson.Raw) error {
 	o.EnforcerID = s.EnforcerID
 	o.EnforcerNamespace = s.EnforcerNamespace
 	o.MigrationsLog = s.MigrationsLog
+	o.Namespace = s.Namespace
 	o.ProcessingUnitID = s.ProcessingUnitID
 	o.ProcessingUnitNamespace = s.ProcessingUnitNamespace
 	o.Protocol = s.Protocol
@@ -315,6 +320,18 @@ func (o *ConnectionExceptionReport) SetMigrationsLog(migrationsLog map[string]st
 	o.MigrationsLog = migrationsLog
 }
 
+// GetNamespace returns the Namespace of the receiver.
+func (o *ConnectionExceptionReport) GetNamespace() string {
+
+	return o.Namespace
+}
+
+// SetNamespace sets the property Namespace of the receiver using the given value.
+func (o *ConnectionExceptionReport) SetNamespace(namespace string) {
+
+	o.Namespace = namespace
+}
+
 // GetZHash returns the ZHash of the receiver.
 func (o *ConnectionExceptionReport) GetZHash() int {
 
@@ -354,6 +371,7 @@ func (o *ConnectionExceptionReport) ToSparse(fields ...string) elemental.SparseI
 			EnforcerID:                  &o.EnforcerID,
 			EnforcerNamespace:           &o.EnforcerNamespace,
 			MigrationsLog:               &o.MigrationsLog,
+			Namespace:                   &o.Namespace,
 			ProcessingUnitID:            &o.ProcessingUnitID,
 			ProcessingUnitNamespace:     &o.ProcessingUnitNamespace,
 			Protocol:                    &o.Protocol,
@@ -387,6 +405,8 @@ func (o *ConnectionExceptionReport) ToSparse(fields ...string) elemental.SparseI
 			sp.EnforcerNamespace = &(o.EnforcerNamespace)
 		case "migrationsLog":
 			sp.MigrationsLog = &(o.MigrationsLog)
+		case "namespace":
+			sp.Namespace = &(o.Namespace)
 		case "processingUnitID":
 			sp.ProcessingUnitID = &(o.ProcessingUnitID)
 		case "processingUnitNamespace":
@@ -445,6 +465,9 @@ func (o *ConnectionExceptionReport) Patch(sparse elemental.SparseIdentifiable) {
 	}
 	if so.MigrationsLog != nil {
 		o.MigrationsLog = *so.MigrationsLog
+	}
+	if so.Namespace != nil {
+		o.Namespace = *so.Namespace
 	}
 	if so.ProcessingUnitID != nil {
 		o.ProcessingUnitID = *so.ProcessingUnitID
@@ -589,6 +612,8 @@ func (o *ConnectionExceptionReport) ValueForAttribute(name string) interface{} {
 		return o.EnforcerNamespace
 	case "migrationsLog":
 		return o.MigrationsLog
+	case "namespace":
+		return o.Namespace
 	case "processingUnitID":
 		return o.ProcessingUnitID
 	case "processingUnitNamespace":
@@ -709,6 +734,20 @@ state.`,
 		Stored:         true,
 		SubType:        "map[string]string",
 		Type:           "external",
+	},
+	"Namespace": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "p",
+		ConvertedName:  "Namespace",
+		Description:    `Namespace of the processing unit encountered this exception.`,
+		Exposed:        true,
+		Filterable:     true,
+		Getter:         true,
+		Name:           "namespace",
+		ReadOnly:       true,
+		Setter:         true,
+		Stored:         true,
+		Type:           "string",
 	},
 	"ProcessingUnitID": {
 		AllowedChoices: []string{},
@@ -931,6 +970,20 @@ state.`,
 		SubType:        "map[string]string",
 		Type:           "external",
 	},
+	"namespace": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "p",
+		ConvertedName:  "Namespace",
+		Description:    `Namespace of the processing unit encountered this exception.`,
+		Exposed:        true,
+		Filterable:     true,
+		Getter:         true,
+		Name:           "namespace",
+		ReadOnly:       true,
+		Setter:         true,
+		Stored:         true,
+		Type:           "string",
+	},
 	"processingunitid": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "g",
@@ -1147,6 +1200,9 @@ type SparseConnectionExceptionReport struct {
 	// Internal property maintaining migrations information.
 	MigrationsLog *map[string]string `json:"-" msgpack:"-" bson:"migrationslog,omitempty" mapstructure:"-,omitempty"`
 
+	// Namespace of the processing unit encountered this exception.
+	Namespace *string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"p,omitempty" mapstructure:"namespace,omitempty"`
+
 	// ID of the processing unit encountered this exception.
 	ProcessingUnitID *string `json:"processingUnitID,omitempty" msgpack:"processingUnitID,omitempty" bson:"g,omitempty" mapstructure:"processingUnitID,omitempty"`
 
@@ -1248,6 +1304,9 @@ func (o *SparseConnectionExceptionReport) GetBSON() (interface{}, error) {
 	if o.MigrationsLog != nil {
 		s.MigrationsLog = o.MigrationsLog
 	}
+	if o.Namespace != nil {
+		s.Namespace = o.Namespace
+	}
 	if o.ProcessingUnitID != nil {
 		s.ProcessingUnitID = o.ProcessingUnitID
 	}
@@ -1321,6 +1380,9 @@ func (o *SparseConnectionExceptionReport) SetBSON(raw bson.Raw) error {
 	if s.MigrationsLog != nil {
 		o.MigrationsLog = s.MigrationsLog
 	}
+	if s.Namespace != nil {
+		o.Namespace = s.Namespace
+	}
 	if s.ProcessingUnitID != nil {
 		o.ProcessingUnitID = s.ProcessingUnitID
 	}
@@ -1392,6 +1454,9 @@ func (o *SparseConnectionExceptionReport) ToPlain() elemental.PlainIdentifiable 
 	if o.MigrationsLog != nil {
 		out.MigrationsLog = *o.MigrationsLog
 	}
+	if o.Namespace != nil {
+		out.Namespace = *o.Namespace
+	}
 	if o.ProcessingUnitID != nil {
 		out.ProcessingUnitID = *o.ProcessingUnitID
 	}
@@ -1443,6 +1508,22 @@ func (o *SparseConnectionExceptionReport) GetMigrationsLog() (out map[string]str
 func (o *SparseConnectionExceptionReport) SetMigrationsLog(migrationsLog map[string]string) {
 
 	o.MigrationsLog = &migrationsLog
+}
+
+// GetNamespace returns the Namespace of the receiver.
+func (o *SparseConnectionExceptionReport) GetNamespace() (out string) {
+
+	if o.Namespace == nil {
+		return
+	}
+
+	return *o.Namespace
+}
+
+// SetNamespace sets the property Namespace of the receiver using the address of the given value.
+func (o *SparseConnectionExceptionReport) SetNamespace(namespace string) {
+
+	o.Namespace = &namespace
 }
 
 // GetZHash returns the ZHash of the receiver.
@@ -1510,6 +1591,7 @@ type mongoAttributesConnectionExceptionReport struct {
 	EnforcerID                  string                                    `bson:"e,omitempty"`
 	EnforcerNamespace           string                                    `bson:"f,omitempty"`
 	MigrationsLog               map[string]string                         `bson:"migrationslog,omitempty"`
+	Namespace                   string                                    `bson:"p,omitempty"`
 	ProcessingUnitID            string                                    `bson:"g,omitempty"`
 	ProcessingUnitNamespace     string                                    `bson:"h,omitempty"`
 	Protocol                    int                                       `bson:"i,omitempty"`
@@ -1531,6 +1613,7 @@ type mongoAttributesSparseConnectionExceptionReport struct {
 	EnforcerID                  *string                                    `bson:"e,omitempty"`
 	EnforcerNamespace           *string                                    `bson:"f,omitempty"`
 	MigrationsLog               *map[string]string                         `bson:"migrationslog,omitempty"`
+	Namespace                   *string                                    `bson:"p,omitempty"`
 	ProcessingUnitID            *string                                    `bson:"g,omitempty"`
 	ProcessingUnitNamespace     *string                                    `bson:"h,omitempty"`
 	Protocol                    *int                                       `bson:"i,omitempty"`

--- a/connectionexceptionreport.go
+++ b/connectionexceptionreport.go
@@ -138,7 +138,7 @@ type ConnectionExceptionReport struct {
 	// Internal property maintaining migrations information.
 	MigrationsLog map[string]string `json:"-" msgpack:"-" bson:"migrationslog,omitempty" mapstructure:"-,omitempty"`
 
-	// Namespace of the processing unit encountered this exception.
+	// Namespace of the processing unit that encountered this exception.
 	Namespace string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"p,omitempty" mapstructure:"namespace,omitempty"`
 
 	// ID of the processing unit encountered this exception.
@@ -562,6 +562,11 @@ func (o *ConnectionExceptionReport) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
+	// Custom object validation.
+	if err := ValidateConnectionExceptionReport(o); err != nil {
+		errors = errors.Append(err)
+	}
+
 	if len(requiredErrors) > 0 {
 		return requiredErrors
 	}
@@ -739,7 +744,7 @@ state.`,
 		AllowedChoices: []string{},
 		BSONFieldName:  "p",
 		ConvertedName:  "Namespace",
-		Description:    `Namespace of the processing unit encountered this exception.`,
+		Description:    `Namespace of the processing unit that encountered this exception.`,
 		Exposed:        true,
 		Filterable:     true,
 		Getter:         true,
@@ -974,7 +979,7 @@ state.`,
 		AllowedChoices: []string{},
 		BSONFieldName:  "p",
 		ConvertedName:  "Namespace",
-		Description:    `Namespace of the processing unit encountered this exception.`,
+		Description:    `Namespace of the processing unit that encountered this exception.`,
 		Exposed:        true,
 		Filterable:     true,
 		Getter:         true,
@@ -1200,7 +1205,7 @@ type SparseConnectionExceptionReport struct {
 	// Internal property maintaining migrations information.
 	MigrationsLog *map[string]string `json:"-" msgpack:"-" bson:"migrationslog,omitempty" mapstructure:"-,omitempty"`
 
-	// Namespace of the processing unit encountered this exception.
+	// Namespace of the processing unit that encountered this exception.
 	Namespace *string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"p,omitempty" mapstructure:"namespace,omitempty"`
 
 	// ID of the processing unit encountered this exception.

--- a/counterreport.go
+++ b/counterreport.go
@@ -291,6 +291,9 @@ type CounterReport struct {
 	// Internal property maintaining migrations information.
 	MigrationsLog map[string]string `json:"-" msgpack:"-" bson:"migrationslog,omitempty" mapstructure:"-,omitempty"`
 
+	// Namespace of the enforcer sending the report.
+	Namespace string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"bt,omitempty" mapstructure:"namespace,omitempty"`
+
 	// Non-zero counter indicates packets dropped due to a reject policy.
 	PolicyDrops int `json:"policyDrops,omitempty" msgpack:"policyDrops,omitempty" bson:"bo,omitempty" mapstructure:"policyDrops,omitempty"`
 
@@ -423,6 +426,7 @@ func (o *CounterReport) GetBSON() (interface{}, error) {
 	s.EnforcerNamespace = o.EnforcerNamespace
 	s.ExternalNetworkConnections = o.ExternalNetworkConnections
 	s.MigrationsLog = o.MigrationsLog
+	s.Namespace = o.Namespace
 	s.PolicyDrops = o.PolicyDrops
 	s.ProcessingUnitID = o.ProcessingUnitID
 	s.ProcessingUnitNamespace = o.ProcessingUnitNamespace
@@ -514,6 +518,7 @@ func (o *CounterReport) SetBSON(raw bson.Raw) error {
 	o.EnforcerNamespace = s.EnforcerNamespace
 	o.ExternalNetworkConnections = s.ExternalNetworkConnections
 	o.MigrationsLog = s.MigrationsLog
+	o.Namespace = s.Namespace
 	o.PolicyDrops = s.PolicyDrops
 	o.ProcessingUnitID = s.ProcessingUnitID
 	o.ProcessingUnitNamespace = s.ProcessingUnitNamespace
@@ -566,6 +571,18 @@ func (o *CounterReport) GetMigrationsLog() map[string]string {
 func (o *CounterReport) SetMigrationsLog(migrationsLog map[string]string) {
 
 	o.MigrationsLog = migrationsLog
+}
+
+// GetNamespace returns the Namespace of the receiver.
+func (o *CounterReport) GetNamespace() string {
+
+	return o.Namespace
+}
+
+// SetNamespace sets the property Namespace of the receiver using the given value.
+func (o *CounterReport) SetNamespace(namespace string) {
+
+	o.Namespace = namespace
 }
 
 // GetZHash returns the ZHash of the receiver.
@@ -666,6 +683,7 @@ func (o *CounterReport) ToSparse(fields ...string) elemental.SparseIdentifiable 
 			EnforcerNamespace:            &o.EnforcerNamespace,
 			ExternalNetworkConnections:   &o.ExternalNetworkConnections,
 			MigrationsLog:                &o.MigrationsLog,
+			Namespace:                    &o.Namespace,
 			PolicyDrops:                  &o.PolicyDrops,
 			ProcessingUnitID:             &o.ProcessingUnitID,
 			ProcessingUnitNamespace:      &o.ProcessingUnitNamespace,
@@ -813,6 +831,8 @@ func (o *CounterReport) ToSparse(fields ...string) elemental.SparseIdentifiable 
 			sp.ExternalNetworkConnections = &(o.ExternalNetworkConnections)
 		case "migrationsLog":
 			sp.MigrationsLog = &(o.MigrationsLog)
+		case "namespace":
+			sp.Namespace = &(o.Namespace)
 		case "policyDrops":
 			sp.PolicyDrops = &(o.PolicyDrops)
 		case "processingUnitID":
@@ -1040,6 +1060,9 @@ func (o *CounterReport) Patch(sparse elemental.SparseIdentifiable) {
 	}
 	if so.MigrationsLog != nil {
 		o.MigrationsLog = *so.MigrationsLog
+	}
+	if so.Namespace != nil {
+		o.Namespace = *so.Namespace
 	}
 	if so.PolicyDrops != nil {
 		o.PolicyDrops = *so.PolicyDrops
@@ -1270,6 +1293,8 @@ func (o *CounterReport) ValueForAttribute(name string) interface{} {
 		return o.ExternalNetworkConnections
 	case "migrationsLog":
 		return o.MigrationsLog
+	case "namespace":
+		return o.Namespace
 	case "policyDrops":
 		return o.PolicyDrops
 	case "processingUnitID":
@@ -1976,6 +2001,20 @@ These may be drops or allowed counters.`,
 		Stored:         true,
 		SubType:        "map[string]string",
 		Type:           "external",
+	},
+	"Namespace": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "bt",
+		ConvertedName:  "Namespace",
+		Description:    `Namespace of the enforcer sending the report.`,
+		Exposed:        true,
+		Filterable:     true,
+		Getter:         true,
+		Name:           "namespace",
+		ReadOnly:       true,
+		Setter:         true,
+		Stored:         true,
+		Type:           "string",
 	},
 	"PolicyDrops": {
 		AllowedChoices: []string{},
@@ -2749,6 +2788,20 @@ These may be drops or allowed counters.`,
 		SubType:        "map[string]string",
 		Type:           "external",
 	},
+	"namespace": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "bt",
+		ConvertedName:  "Namespace",
+		Description:    `Namespace of the enforcer sending the report.`,
+		Exposed:        true,
+		Filterable:     true,
+		Getter:         true,
+		Name:           "namespace",
+		ReadOnly:       true,
+		Setter:         true,
+		Stored:         true,
+		Type:           "string",
+	},
 	"policydrops": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "bo",
@@ -3106,6 +3159,9 @@ type SparseCounterReport struct {
 	// Internal property maintaining migrations information.
 	MigrationsLog *map[string]string `json:"-" msgpack:"-" bson:"migrationslog,omitempty" mapstructure:"-,omitempty"`
 
+	// Namespace of the enforcer sending the report.
+	Namespace *string `json:"namespace,omitempty" msgpack:"namespace,omitempty" bson:"bt,omitempty" mapstructure:"namespace,omitempty"`
+
 	// Non-zero counter indicates packets dropped due to a reject policy.
 	PolicyDrops *int `json:"policyDrops,omitempty" msgpack:"policyDrops,omitempty" bson:"bo,omitempty" mapstructure:"policyDrops,omitempty"`
 
@@ -3373,6 +3429,9 @@ func (o *SparseCounterReport) GetBSON() (interface{}, error) {
 	if o.MigrationsLog != nil {
 		s.MigrationsLog = o.MigrationsLog
 	}
+	if o.Namespace != nil {
+		s.Namespace = o.Namespace
+	}
 	if o.PolicyDrops != nil {
 		s.PolicyDrops = o.PolicyDrops
 	}
@@ -3611,6 +3670,9 @@ func (o *SparseCounterReport) SetBSON(raw bson.Raw) error {
 	if s.MigrationsLog != nil {
 		o.MigrationsLog = s.MigrationsLog
 	}
+	if s.Namespace != nil {
+		o.Namespace = s.Namespace
+	}
 	if s.PolicyDrops != nil {
 		o.PolicyDrops = s.PolicyDrops
 	}
@@ -3847,6 +3909,9 @@ func (o *SparseCounterReport) ToPlain() elemental.PlainIdentifiable {
 	if o.MigrationsLog != nil {
 		out.MigrationsLog = *o.MigrationsLog
 	}
+	if o.Namespace != nil {
+		out.Namespace = *o.Namespace
+	}
 	if o.PolicyDrops != nil {
 		out.PolicyDrops = *o.PolicyDrops
 	}
@@ -3886,6 +3951,22 @@ func (o *SparseCounterReport) GetMigrationsLog() (out map[string]string) {
 func (o *SparseCounterReport) SetMigrationsLog(migrationsLog map[string]string) {
 
 	o.MigrationsLog = &migrationsLog
+}
+
+// GetNamespace returns the Namespace of the receiver.
+func (o *SparseCounterReport) GetNamespace() (out string) {
+
+	if o.Namespace == nil {
+		return
+	}
+
+	return *o.Namespace
+}
+
+// SetNamespace sets the property Namespace of the receiver using the address of the given value.
+func (o *SparseCounterReport) SetNamespace(namespace string) {
+
+	o.Namespace = &namespace
 }
 
 // GetZHash returns the ZHash of the receiver.
@@ -4012,6 +4093,7 @@ type mongoAttributesCounterReport struct {
 	EnforcerNamespace            string            `bson:"bm,omitempty"`
 	ExternalNetworkConnections   int               `bson:"bn,omitempty"`
 	MigrationsLog                map[string]string `bson:"migrationslog,omitempty"`
+	Namespace                    string            `bson:"bt,omitempty"`
 	PolicyDrops                  int               `bson:"bo,omitempty"`
 	ProcessingUnitID             string            `bson:"bp,omitempty"`
 	ProcessingUnitNamespace      string            `bson:"bq,omitempty"`
@@ -4088,6 +4170,7 @@ type mongoAttributesSparseCounterReport struct {
 	EnforcerNamespace            *string            `bson:"bm,omitempty"`
 	ExternalNetworkConnections   *int               `bson:"bn,omitempty"`
 	MigrationsLog                *map[string]string `bson:"migrationslog,omitempty"`
+	Namespace                    *string            `bson:"bt,omitempty"`
 	PolicyDrops                  *int               `bson:"bo,omitempty"`
 	ProcessingUnitID             *string            `bson:"bp,omitempty"`
 	ProcessingUnitNamespace      *string            `bson:"bq,omitempty"`

--- a/counterreport.go
+++ b/counterreport.go
@@ -281,7 +281,9 @@ type CounterReport struct {
 	// Identifier of the enforcer sending the report.
 	EnforcerID string `json:"enforcerID,omitempty" msgpack:"enforcerID,omitempty" bson:"bl,omitempty" mapstructure:"enforcerID,omitempty"`
 
-	// Namespace of the enforcer sending the report.
+	// Namespace of the enforcer sending the report. This field is deprecated. Use the
+	// 'namespace' field instead.
+	// field instead.
 	EnforcerNamespace string `json:"enforcerNamespace,omitempty" msgpack:"enforcerNamespace,omitempty" bson:"bm,omitempty" mapstructure:"enforcerNamespace,omitempty"`
 
 	// Non-zero counter indicates connections going to and from external networks.
@@ -1121,8 +1123,9 @@ func (o *CounterReport) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
-	if err := elemental.ValidateRequiredString("enforcerNamespace", o.EnforcerNamespace); err != nil {
-		requiredErrors = requiredErrors.Append(err)
+	// Custom object validation.
+	if err := ValidateCounterReport(o); err != nil {
+		errors = errors.Append(err)
 	}
 
 	if len(requiredErrors) > 0 {
@@ -1972,12 +1975,14 @@ rules and queue drops.`,
 		AllowedChoices: []string{},
 		BSONFieldName:  "bm",
 		ConvertedName:  "EnforcerNamespace",
-		Description:    `Namespace of the enforcer sending the report.`,
-		Exposed:        true,
-		Name:           "enforcerNamespace",
-		Required:       true,
-		Stored:         true,
-		Type:           "string",
+		Deprecated:     true,
+		Description: `Namespace of the enforcer sending the report. This field is deprecated. Use the
+'namespace' field instead.
+field instead.`,
+		Exposed: true,
+		Name:    "enforcerNamespace",
+		Stored:  true,
+		Type:    "string",
 	},
 	"ExternalNetworkConnections": {
 		AllowedChoices: []string{},
@@ -2758,12 +2763,14 @@ rules and queue drops.`,
 		AllowedChoices: []string{},
 		BSONFieldName:  "bm",
 		ConvertedName:  "EnforcerNamespace",
-		Description:    `Namespace of the enforcer sending the report.`,
-		Exposed:        true,
-		Name:           "enforcerNamespace",
-		Required:       true,
-		Stored:         true,
-		Type:           "string",
+		Deprecated:     true,
+		Description: `Namespace of the enforcer sending the report. This field is deprecated. Use the
+'namespace' field instead.
+field instead.`,
+		Exposed: true,
+		Name:    "enforcerNamespace",
+		Stored:  true,
+		Type:    "string",
 	},
 	"externalnetworkconnections": {
 		AllowedChoices: []string{},
@@ -3149,7 +3156,9 @@ type SparseCounterReport struct {
 	// Identifier of the enforcer sending the report.
 	EnforcerID *string `json:"enforcerID,omitempty" msgpack:"enforcerID,omitempty" bson:"bl,omitempty" mapstructure:"enforcerID,omitempty"`
 
-	// Namespace of the enforcer sending the report.
+	// Namespace of the enforcer sending the report. This field is deprecated. Use the
+	// 'namespace' field instead.
+	// field instead.
 	EnforcerNamespace *string `json:"enforcerNamespace,omitempty" msgpack:"enforcerNamespace,omitempty" bson:"bm,omitempty" mapstructure:"enforcerNamespace,omitempty"`
 
 	// Non-zero counter indicates connections going to and from external networks.

--- a/custom_validations.go
+++ b/custom_validations.go
@@ -1180,7 +1180,6 @@ func ValidateConnectionExceptionReport(report *ConnectionExceptionReport) error 
 	return nil
 }
 
-
 // ValidateCounterReport validates a CounterReport.
 func ValidateCounterReport(report *CounterReport) error {
 

--- a/custom_validations.go
+++ b/custom_validations.go
@@ -1161,3 +1161,40 @@ func ValidateDNSLookupReport(report *DNSLookupReport) error {
 
 	return nil
 }
+
+// ValidateConnectionExceptionReport validates a ConnectionExceptionReport.
+func ValidateConnectionExceptionReport(report *ConnectionExceptionReport) error {
+
+	// remain backwards compatible with old enforcers that are still only reporting the 'ProcessingUnitNamespace' field
+	// by taking the value they supply for the 'ProcessingUnitNamespace' field and using that to populate the 'Namespace'
+	// field.
+	if report.Namespace == "" && report.ProcessingUnitNamespace != "" {
+		report.Namespace = report.ProcessingUnitNamespace
+		report.ProcessingUnitNamespace = ""
+	} else if report.Namespace != "" && report.ProcessingUnitNamespace != "" {
+		return makeValidationError("namespace", "Both 'namespace' and 'processingUnitNamespace' cannot be set")
+	} else if report.Namespace == "" && report.ProcessingUnitNamespace == "" {
+		return makeValidationError("namespace", "Attribute 'namespace' is required")
+	}
+
+	return nil
+}
+
+
+// ValidateCounterReport validates a CounterReport.
+func ValidateCounterReport(report *CounterReport) error {
+
+	// remain backwards compatible with old enforcers that are still only reporting the 'EnforcerNamespace' field
+	// by taking the value they supply for the 'EnforcerNamespace' field and using that to populate the 'Namespace'
+	// field.
+	if report.Namespace == "" && report.EnforcerNamespace != "" {
+		report.Namespace = report.EnforcerNamespace
+		report.EnforcerNamespace = ""
+	} else if report.Namespace != "" && report.EnforcerNamespace != "" {
+		return makeValidationError("namespace", "Both 'namespace' and 'enforcerNamespace' cannot be set")
+	} else if report.Namespace == "" && report.EnforcerNamespace == "" {
+		return makeValidationError("namespace", "Attribute 'namespace' is required")
+	}
+
+	return nil
+}

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -3449,14 +3449,14 @@ func TestValidateCounterReport(t *testing.T) {
 		},
 		"both the 'enforcerNamespace' and 'namespace' fields have been left omitted": {
 			report: &CounterReport{
-				Namespace:               "",
+				Namespace:         "",
 				EnforcerNamespace: "",
 			},
 			wantErr: true,
 		},
 		"both the 'enforcerNamespace' and 'namespace' fields have been provided": {
 			report: &CounterReport{
-				Namespace:               "my/namespace",
+				Namespace:         "my/namespace",
 				EnforcerNamespace: "my/namespace",
 			},
 			wantErr: true,

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -3372,3 +3372,115 @@ func TestValidateDNSLookupReport(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateConnectionExceptionReport(t *testing.T) {
+
+	tests := map[string]struct {
+		report  *ConnectionExceptionReport
+		wantErr bool
+	}{
+		"only the 'namespace' field is specified": {
+			report: &ConnectionExceptionReport{
+				Namespace: "my/namespace",
+			},
+			wantErr: false,
+		},
+		"only the 'processingUnitNamespace' field is specified": {
+			report: &ConnectionExceptionReport{
+				ProcessingUnitNamespace: "my/namespace",
+			},
+			wantErr: false,
+		},
+		"both the 'processingUnitNamespace' and 'namespace' fields have been left omitted": {
+			report: &ConnectionExceptionReport{
+				Namespace:               "",
+				ProcessingUnitNamespace: "",
+			},
+			wantErr: true,
+		},
+		"both the 'processingUnitNamespace' and 'namespace' fields have been provided": {
+			report: &ConnectionExceptionReport{
+				Namespace:               "my/namespace",
+				ProcessingUnitNamespace: "my/namespace",
+			},
+			wantErr: true,
+		},
+	}
+
+	for description, scenario := range tests {
+		t.Run(description, func(t *testing.T) {
+			var err error
+			if err = ValidateConnectionExceptionReport(scenario.report); (err != nil) != scenario.wantErr {
+				t.Errorf("TestValidateConnectionExceptionReport() error = %s, expected an error? %t", err, scenario.wantErr)
+			}
+
+			// verify that ONLY the `namespace` field is populated so the backend processors do not need to worry about
+			// dealing with the 'processingUnitNamespace' field being set
+			if err == nil {
+				if scenario.report.ProcessingUnitNamespace != "" {
+					t.Errorf("Validation passed, but the report's 'processingUnitNamespace' field was NOT reset. It contained the value: %s", scenario.report.ID)
+				}
+
+				if scenario.report.Namespace == "" {
+					t.Error("Validation passed, but the report's 'namespace' field was empty")
+				}
+			}
+		})
+	}
+}
+
+func TestValidateCounterReport(t *testing.T) {
+
+	tests := map[string]struct {
+		report  *CounterReport
+		wantErr bool
+	}{
+		"only the 'namespace' field is specified": {
+			report: &CounterReport{
+				Namespace: "my/namespace",
+			},
+			wantErr: false,
+		},
+		"only the 'enforcerNamespace' field is specified": {
+			report: &CounterReport{
+				EnforcerNamespace: "my/namespace",
+			},
+			wantErr: false,
+		},
+		"both the 'enforcerNamespace' and 'namespace' fields have been left omitted": {
+			report: &CounterReport{
+				Namespace:               "",
+				EnforcerNamespace: "",
+			},
+			wantErr: true,
+		},
+		"both the 'enforcerNamespace' and 'namespace' fields have been provided": {
+			report: &CounterReport{
+				Namespace:               "my/namespace",
+				EnforcerNamespace: "my/namespace",
+			},
+			wantErr: true,
+		},
+	}
+
+	for description, scenario := range tests {
+		t.Run(description, func(t *testing.T) {
+			var err error
+			if err = ValidateCounterReport(scenario.report); (err != nil) != scenario.wantErr {
+				t.Errorf("TestValidateCounterReport() error = %s, expected an error? %t", err, scenario.wantErr)
+			}
+
+			// verify that ONLY the `namespace` field is populated so the backend processors do not need to worry about
+			// dealing with the 'enforcerNamespace' field being set
+			if err == nil {
+				if scenario.report.EnforcerNamespace != "" {
+					t.Errorf("Validation passed, but the report's 'enforcerNamespace' field was NOT reset. It contained the value: %s", scenario.report.ID)
+				}
+
+				if scenario.report.Namespace == "" {
+					t.Error("Validation passed, but the report's 'namespace' field was empty")
+				}
+			}
+		})
+	}
+}

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -2283,6 +2283,7 @@ Post a new counter tracing report.
 {
   "enforcerID": "xxxx-xxx-xxxx",
   "enforcerNamespace": "/my/namespace",
+  "namespace": "/my/namespace",
   "processingUnitID": "xxx-xxx-xxx",
   "processingUnitNamespace": "/my/namespace",
   "timestamp": "2018-06-14T23:10:46.420397985Z"
@@ -2699,6 +2700,12 @@ Type: `integer`
 
 Non-zero counter indicates connections going to and from external networks.
 These may be drops or allowed counters.
+
+##### `namespace` [`read_only`]
+
+Type: `string`
+
+Namespace of the enforcer sending the report.
 
 ##### `policyDrops`
 
@@ -12608,6 +12615,7 @@ Post a new flow log.
   "destinationProcessingUnitID": "xxx-xxx-xxx",
   "enforcerID": "xxx-xxx-xxx",
   "enforcerNamespace": "/my/namespace",
+  "namespace": "/my/namespace",
   "processingUnitID": "xxx-xxx-xxx",
   "processingUnitNamespace": "/my/namespace",
   "protocol": 6,
@@ -12674,6 +12682,12 @@ _This attribute is deprecated_.
 Type: `string`
 
 Namespace of the enforcer.
+
+##### `namespace` [`read_only`]
+
+Type: `string`
+
+Namespace of the processing unit encountered this exception.
 
 ##### `processingUnitID` [`required`]
 
@@ -16563,6 +16577,12 @@ Mandatory Parameters
 Type: [`[]dnslookupreport`](#dnslookupreport)
 
 List of DNSLookupReports.
+
+##### `connectionExceptionReports`
+
+Type: [`[]connectionexceptionreport`](#connectionexceptionreport)
+
+List of ConnectionExceptionReports.
 
 ##### `counterReports`
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -2688,11 +2688,15 @@ Type: `string`
 
 Identifier of the enforcer sending the report.
 
-##### `enforcerNamespace` [`required`]
+##### `enforcerNamespace`
+
+_This attribute is deprecated_.
 
 Type: `string`
 
-Namespace of the enforcer sending the report.
+Namespace of the enforcer sending the report. This field is deprecated. Use the
+'namespace' field instead.
+field instead.
 
 ##### `externalNetworkConnections`
 
@@ -12687,7 +12691,7 @@ Namespace of the enforcer.
 
 Type: `string`
 
-Namespace of the processing unit encountered this exception.
+Namespace of the processing unit that encountered this exception.
 
 ##### `processingUnitID` [`required`]
 
@@ -16616,7 +16620,7 @@ List of PacketReports.
 
 ##### `report`
 
-Type: `enum(Flows | Enforcers | EventLogs | Packets | Counters | DNSLookups)`
+Type: `enum(Flows | Enforcers | EventLogs | Packets | Counters | DNSLookups | ConnectionExceptions)`
 
 Name of the report type to query.
 

--- a/identities_registry.go
+++ b/identities_registry.go
@@ -571,6 +571,7 @@ var (
 		"cnssuggestion": nil,
 		"connectionexceptionreport": {
 			{"processingunitnamespace", "timestamp"},
+			{"namespace", "timestamp"},
 			{"enforcernamespace", "timestamp"},
 			{":shard", "zone", "zHash", "_id"},
 		},

--- a/reportsquery.go
+++ b/reportsquery.go
@@ -106,6 +106,9 @@ type ReportsQuery struct {
 	// List of DNSLookupReports.
 	DNSLookupReports DNSLookupReportsList `json:"DNSLookupReports,omitempty" msgpack:"DNSLookupReports,omitempty" bson:"-" mapstructure:"DNSLookupReports,omitempty"`
 
+	// List of ConnectionExceptionReports.
+	ConnectionExceptionReports ConnectionExceptionReportsList `json:"connectionExceptionReports,omitempty" msgpack:"connectionExceptionReports,omitempty" bson:"-" mapstructure:"connectionExceptionReports,omitempty"`
+
 	// List of CounterReports.
 	CounterReports CounterReportsList `json:"counterReports,omitempty" msgpack:"counterReports,omitempty" bson:"-" mapstructure:"counterReports,omitempty"`
 
@@ -131,14 +134,15 @@ type ReportsQuery struct {
 func NewReportsQuery() *ReportsQuery {
 
 	return &ReportsQuery{
-		ModelVersion:     1,
-		CounterReports:   CounterReportsList{},
-		DNSLookupReports: DNSLookupReportsList{},
-		EnforcerReports:  EnforcerReportsList{},
-		EventLogs:        EventLogsList{},
-		FlowReports:      FlowReportsList{},
-		PacketReports:    PacketReportsList{},
-		Report:           ReportsQueryReportFlows,
+		ModelVersion:               1,
+		ConnectionExceptionReports: ConnectionExceptionReportsList{},
+		DNSLookupReports:           DNSLookupReportsList{},
+		CounterReports:             CounterReportsList{},
+		EnforcerReports:            EnforcerReportsList{},
+		EventLogs:                  EventLogsList{},
+		FlowReports:                FlowReportsList{},
+		PacketReports:              PacketReportsList{},
+		Report:                     ReportsQueryReportFlows,
 	}
 }
 
@@ -225,13 +229,14 @@ func (o *ReportsQuery) ToSparse(fields ...string) elemental.SparseIdentifiable {
 	if len(fields) == 0 {
 		// nolint: goimports
 		return &SparseReportsQuery{
-			DNSLookupReports: &o.DNSLookupReports,
-			CounterReports:   &o.CounterReports,
-			EnforcerReports:  &o.EnforcerReports,
-			EventLogs:        &o.EventLogs,
-			FlowReports:      &o.FlowReports,
-			PacketReports:    &o.PacketReports,
-			Report:           &o.Report,
+			DNSLookupReports:           &o.DNSLookupReports,
+			ConnectionExceptionReports: &o.ConnectionExceptionReports,
+			CounterReports:             &o.CounterReports,
+			EnforcerReports:            &o.EnforcerReports,
+			EventLogs:                  &o.EventLogs,
+			FlowReports:                &o.FlowReports,
+			PacketReports:              &o.PacketReports,
+			Report:                     &o.Report,
 		}
 	}
 
@@ -240,6 +245,8 @@ func (o *ReportsQuery) ToSparse(fields ...string) elemental.SparseIdentifiable {
 		switch f {
 		case "DNSLookupReports":
 			sp.DNSLookupReports = &(o.DNSLookupReports)
+		case "connectionExceptionReports":
+			sp.ConnectionExceptionReports = &(o.ConnectionExceptionReports)
 		case "counterReports":
 			sp.CounterReports = &(o.CounterReports)
 		case "enforcerReports":
@@ -267,6 +274,9 @@ func (o *ReportsQuery) Patch(sparse elemental.SparseIdentifiable) {
 	so := sparse.(*SparseReportsQuery)
 	if so.DNSLookupReports != nil {
 		o.DNSLookupReports = *so.DNSLookupReports
+	}
+	if so.ConnectionExceptionReports != nil {
+		o.ConnectionExceptionReports = *so.ConnectionExceptionReports
 	}
 	if so.CounterReports != nil {
 		o.CounterReports = *so.CounterReports
@@ -319,6 +329,16 @@ func (o *ReportsQuery) Validate() error {
 	requiredErrors := elemental.Errors{}
 
 	for _, sub := range o.DNSLookupReports {
+		if sub == nil {
+			continue
+		}
+		elemental.ResetDefaultForZeroValues(sub)
+		if err := sub.Validate(); err != nil {
+			errors = errors.Append(err)
+		}
+	}
+
+	for _, sub := range o.ConnectionExceptionReports {
 		if sub == nil {
 			continue
 		}
@@ -418,6 +438,8 @@ func (o *ReportsQuery) ValueForAttribute(name string) interface{} {
 	switch name {
 	case "DNSLookupReports":
 		return o.DNSLookupReports
+	case "connectionExceptionReports":
+		return o.ConnectionExceptionReports
 	case "counterReports":
 		return o.CounterReports
 	case "enforcerReports":
@@ -444,6 +466,15 @@ var ReportsQueryAttributesMap = map[string]elemental.AttributeSpecification{
 		Exposed:        true,
 		Name:           "DNSLookupReports",
 		SubType:        "dnslookupreport",
+		Type:           "refList",
+	},
+	"ConnectionExceptionReports": {
+		AllowedChoices: []string{},
+		ConvertedName:  "ConnectionExceptionReports",
+		Description:    `List of ConnectionExceptionReports.`,
+		Exposed:        true,
+		Name:           "connectionExceptionReports",
+		SubType:        "connectionexceptionreport",
 		Type:           "refList",
 	},
 	"CounterReports": {
@@ -511,6 +542,15 @@ var ReportsQueryLowerCaseAttributesMap = map[string]elemental.AttributeSpecifica
 		Exposed:        true,
 		Name:           "DNSLookupReports",
 		SubType:        "dnslookupreport",
+		Type:           "refList",
+	},
+	"connectionexceptionreports": {
+		AllowedChoices: []string{},
+		ConvertedName:  "ConnectionExceptionReports",
+		Description:    `List of ConnectionExceptionReports.`,
+		Exposed:        true,
+		Name:           "connectionExceptionReports",
+		SubType:        "connectionexceptionreport",
 		Type:           "refList",
 	},
 	"counterreports": {
@@ -635,6 +675,9 @@ type SparseReportsQuery struct {
 	// List of DNSLookupReports.
 	DNSLookupReports *DNSLookupReportsList `json:"DNSLookupReports,omitempty" msgpack:"DNSLookupReports,omitempty" bson:"-" mapstructure:"DNSLookupReports,omitempty"`
 
+	// List of ConnectionExceptionReports.
+	ConnectionExceptionReports *ConnectionExceptionReportsList `json:"connectionExceptionReports,omitempty" msgpack:"connectionExceptionReports,omitempty" bson:"-" mapstructure:"connectionExceptionReports,omitempty"`
+
 	// List of CounterReports.
 	CounterReports *CounterReportsList `json:"counterReports,omitempty" msgpack:"counterReports,omitempty" bson:"-" mapstructure:"counterReports,omitempty"`
 
@@ -719,6 +762,9 @@ func (o *SparseReportsQuery) ToPlain() elemental.PlainIdentifiable {
 	out := NewReportsQuery()
 	if o.DNSLookupReports != nil {
 		out.DNSLookupReports = *o.DNSLookupReports
+	}
+	if o.ConnectionExceptionReports != nil {
+		out.ConnectionExceptionReports = *o.ConnectionExceptionReports
 	}
 	if o.CounterReports != nil {
 		out.CounterReports = *o.CounterReports

--- a/reportsquery.go
+++ b/reportsquery.go
@@ -12,6 +12,9 @@ import (
 type ReportsQueryReportValue string
 
 const (
+	// ReportsQueryReportConnectionExceptions represents the value ConnectionExceptions.
+	ReportsQueryReportConnectionExceptions ReportsQueryReportValue = "ConnectionExceptions"
+
 	// ReportsQueryReportCounters represents the value Counters.
 	ReportsQueryReportCounters ReportsQueryReportValue = "Counters"
 
@@ -398,7 +401,7 @@ func (o *ReportsQuery) Validate() error {
 		}
 	}
 
-	if err := elemental.ValidateStringInList("report", string(o.Report), []string{"Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups"}, false); err != nil {
+	if err := elemental.ValidateStringInList("report", string(o.Report), []string{"Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups", "ConnectionExceptions"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -523,7 +526,7 @@ var ReportsQueryAttributesMap = map[string]elemental.AttributeSpecification{
 		Type:           "refList",
 	},
 	"Report": {
-		AllowedChoices: []string{"Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups"},
+		AllowedChoices: []string{"Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups", "ConnectionExceptions"},
 		ConvertedName:  "Report",
 		DefaultValue:   ReportsQueryReportFlows,
 		Description:    `Name of the report type to query.`,
@@ -599,7 +602,7 @@ var ReportsQueryLowerCaseAttributesMap = map[string]elemental.AttributeSpecifica
 		Type:           "refList",
 	},
 	"report": {
-		AllowedChoices: []string{"Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups"},
+		AllowedChoices: []string{"Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups", "ConnectionExceptions"},
 		ConvertedName:  "Report",
 		DefaultValue:   ReportsQueryReportFlows,
 		Description:    `Name of the report type to query.`,

--- a/specs/_validation.mapping
+++ b/specs/_validation.mapping
@@ -30,6 +30,14 @@ $cidrs:
   elemental:
     name: ValidateCIDRList
 
+$connectionexceptionreport:
+  elemental:
+    name: ValidateConnectionExceptionReport
+
+$counterreport:
+  elemental:
+    name: ValidateCounterReport
+
 $dnslookupreport:
   elemental:
     name: ValidateDNSLookupReport

--- a/specs/connectionexceptionreport.spec
+++ b/specs/connectionexceptionreport.spec
@@ -10,6 +10,8 @@ model:
   - '@identifiable-stored'
   - '@zoned-monotonic'
   - '@migratable'
+  validations:
+  - $connectionexceptionreport
 
 # Indexes
 indexes:
@@ -89,7 +91,7 @@ attributes:
       bson_name: f
 
   - name: namespace
-    description: Namespace of the processing unit encountered this exception.
+    description: Namespace of the processing unit that encountered this exception.
     type: string
     exposed: true
     stored: true

--- a/specs/connectionexceptionreport.spec
+++ b/specs/connectionexceptionreport.spec
@@ -17,6 +17,8 @@ indexes:
   - timestamp
 - - enforcernamespace
   - timestamp
+- - namespace
+  - timestamp
 
 # Attributes
 attributes:
@@ -85,6 +87,20 @@ attributes:
     omit_empty: true
     extensions:
       bson_name: f
+
+  - name: namespace
+    description: Namespace of the processing unit encountered this exception.
+    type: string
+    exposed: true
+    stored: true
+    read_only: true
+    example_value: /my/namespace
+    filterable: true
+    getter: true
+    setter: true
+    omit_empty: true
+    extensions:
+      bson_name: p
 
   - name: processingUnitID
     description: ID of the processing unit encountered this exception.

--- a/specs/counterreport.spec
+++ b/specs/counterreport.spec
@@ -10,6 +10,8 @@ model:
   - '@identifiable-stored'
   - '@zoned-monotonic'
   - '@migratable'
+  validations:
+  - $counterreport
 
 # Ordering
 default_order:
@@ -604,11 +606,14 @@ attributes:
       bson_name: bl
 
   - name: enforcerNamespace
-    description: Namespace of the enforcer sending the report.
+    description: |-
+      Namespace of the enforcer sending the report. This field is deprecated. Use the
+      'namespace' field instead.
+      field instead.
     type: string
     exposed: true
     stored: true
-    required: true
+    deprecated: true
     example_value: /my/namespace
     omit_empty: true
     extensions:

--- a/specs/counterreport.spec
+++ b/specs/counterreport.spec
@@ -540,7 +540,9 @@ attributes:
       bson_name: bf
 
   - name: connectionsAnalyzed
-    description: "Non-zero counter indicates analyzed connections for unencrypted, encrypted, and\npackets from endpoint applications with the TCP Fast Open option set. These are \nnot dropped counter."
+    description: "Non-zero counter indicates analyzed connections for unencrypted,
+      encrypted, and\npackets from endpoint applications with the TCP Fast Open option
+      set. These are \nnot dropped counter."
     type: integer
     exposed: true
     stored: true
@@ -549,7 +551,8 @@ attributes:
       bson_name: bg
 
   - name: connectionsDropped
-    description: "Non-zero counter indicates dropped connections because of invalid state, \nnon-processing unit traffic, or out of order packets."
+    description: "Non-zero counter indicates dropped connections because of invalid
+      state, \nnon-processing unit traffic, or out of order packets."
     type: integer
     exposed: true
     stored: true
@@ -580,7 +583,8 @@ attributes:
       bson_name: bj
 
   - name: encryptionFailures
-    description: Non-zero counter indicates encryption processing failures of data packets.
+    description: Non-zero counter indicates encryption processing failures of data
+      packets.
     type: integer
     exposed: true
     stored: true
@@ -620,6 +624,20 @@ attributes:
     omit_empty: true
     extensions:
       bson_name: bn
+
+  - name: namespace
+    description: Namespace of the enforcer sending the report.
+    type: string
+    exposed: true
+    stored: true
+    read_only: true
+    example_value: /my/namespace
+    filterable: true
+    getter: true
+    setter: true
+    omit_empty: true
+    extensions:
+      bson_name: bt
 
   - name: policyDrops
     description: Non-zero counter indicates packets dropped due to a reject policy.

--- a/specs/reportsquery.spec
+++ b/specs/reportsquery.spec
@@ -74,4 +74,5 @@ attributes:
     - Packets
     - Counters
     - DNSLookups
+    - ConnectionExceptions
     default_value: Flows

--- a/specs/reportsquery.spec
+++ b/specs/reportsquery.spec
@@ -21,6 +21,13 @@ attributes:
     subtype: dnslookupreport
     omit_empty: true
 
+  - name: connectionExceptionReports
+    description: List of ConnectionExceptionReports.
+    type: refList
+    exposed: true
+    subtype: connectionexceptionreport
+    omit_empty: true
+
   - name: counterReports
     description: List of CounterReports.
     type: refList


### PR DESCRIPTION
### Related issue(s)

https://redlock.atlassian.net/browse/CNS-1554

### Project

https://github.com/orgs/aporeto-inc/projects/1021

### Context

This CL does a few things:

- adds a `namespace` property to our `CounterReport` & `ConnectionExceptionReport` models in order to make them queryable by our [reportsqueries API](https://github.com/PaloAltoNetworks/gaia/blob/master/specs/reportsquery.spec).
- adds missing compound index to `ConnectionExceptionReport`
- adds `ReportsQuery` support for `ConnectionExceptionReport`

### What is left TODO

- [x] Enforcer to start consuming the new `namespace` field and including it in API requests
- [x] Backend to deal with the new `namespace` field in a backwards compatible manner that will not break existing/old enforcers:
    - If the new `namespace` field is present, use that. Otherwise, do what you did before.