### PR TITLE
Add gcr repo to avoid rate limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ lint: spelling
 		./...
 
 spelling:
-	docker run --rm -v $$PWD:/workdir tmaier/markdown-spellcheck:latest "doc/*.md" -r -a -n --en-us
+	docker run --rm -v $$PWD:/workdir gcr.io/prismacloud-cns/markdown-spellcheck:latest "doc/*.md" -r -a -n --en-us
 
 test:
 	go test ./... -race


### PR DESCRIPTION
Uses the spell checker from our own repo to avoid rate limits from docker.