### PR TITLE
Unsupported interfaces and validation fixes

### DIFF
--- a/cloudinterfacedata.go
+++ b/cloudinterfacedata.go
@@ -45,6 +45,9 @@ const (
 	// CloudInterfaceDataAttachmentTypeTransitGatewayVPCAttachment represents the value TransitGatewayVPCAttachment.
 	CloudInterfaceDataAttachmentTypeTransitGatewayVPCAttachment CloudInterfaceDataAttachmentTypeValue = "TransitGatewayVPCAttachment"
 
+	// CloudInterfaceDataAttachmentTypeUnsupportedService represents the value UnsupportedService.
+	CloudInterfaceDataAttachmentTypeUnsupportedService CloudInterfaceDataAttachmentTypeValue = "UnsupportedService"
+
 	// CloudInterfaceDataAttachmentTypeVPCEndpoint represents the value VPCEndpoint.
 	CloudInterfaceDataAttachmentTypeVPCEndpoint CloudInterfaceDataAttachmentTypeValue = "VPCEndpoint"
 )
@@ -180,7 +183,7 @@ func (o *CloudInterfaceData) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("attachmentType", string(o.AttachmentType), []string{"Instance", "LoadBalancer", "Gateway", "Service", "TransitGatewayVPCAttachment", "NetworkLoadBalancer", "Lambda", "GatewayLoadBalancer", "GatewayLoadBalancerEndpoint", "VPCEndpoint", "APIGatewayManaged", "EFA"}, false); err != nil {
+	if err := elemental.ValidateStringInList("attachmentType", string(o.AttachmentType), []string{"Instance", "LoadBalancer", "Gateway", "Service", "TransitGatewayVPCAttachment", "NetworkLoadBalancer", "Lambda", "GatewayLoadBalancer", "GatewayLoadBalancerEndpoint", "VPCEndpoint", "APIGatewayManaged", "EFA", "UnsupportedService"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 

--- a/custom_validations.go
+++ b/custom_validations.go
@@ -1328,6 +1328,26 @@ func ValidateCloudNetworkQueryEntity(q *CloudNetworkQuery) error {
 		return makeValidationError("Entity CloudNetworkQuery", "'sourceIP' and 'sourceSelector' cannot be empty at the same time")
 	}
 
+	if q.SourceIP != "" {
+		isPrivate, err := IsAddressPrivate(q.SourceIP)
+		if err != nil {
+			return makeValidationError("Entity CloudNetworkQuery", "'sourceIP' must be a valid IP address")
+		}
+		if isPrivate {
+			return makeValidationError("Entity CloudNetworkQuery", "'sourceIP' must be a public IP address")
+		}
+	}
+
+	if q.DestinationIP != "" {
+		isPrivate, err := IsAddressPrivate(q.DestinationIP)
+		if err != nil {
+			return makeValidationError("Entity CloudNetworkQuery", "'destinationIP' must be a valid IP address")
+		}
+		if isPrivate {
+			return makeValidationError("Entity CloudNetworkQuery", "'destinationIP' must be a public IP address")
+		}
+	}
+
 	emptyDestinationSelector := IsCloudNetworkQueryFilterEmpty(q.DestinationSelector)
 
 	if q.DestinationIP != "" && !emptyDestinationSelector {
@@ -1407,4 +1427,36 @@ func ValidateCloudNetworkQueryFilter(attribute string, f *CloudNetworkQueryFilte
 	}
 
 	return nil
+}
+
+var privateIPSpace = []string{
+	"127.0.0.0/8",    // IPv4 loopback
+	"10.0.0.0/8",     // RFC1918
+	"172.16.0.0/12",  // RFC1918
+	"192.168.0.0/16", // RFC1918
+	"169.254.0.0/16", // RFC3927 link-local
+	"::1/128",        // IPv6 loopback
+	"fe80::/10",      // IPv6 link-local
+	"fc00::/7",       // IPv6 unique local addr
+}
+
+// IsAddressPrivate will check an address and return true if it is
+// part of the private RFC 1918 address spaces.
+func IsAddressPrivate(address string) (bool, error) {
+
+	network, err := ipNetFromString(address)
+	if err != nil {
+		return false, err
+	}
+
+	for _, s := range privateIPSpace {
+		// predefined space
+		_, subnet, _ := net.ParseCIDR(s) // nolint errcheck
+
+		if subnet.Contains(network.IP) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -4064,6 +4064,19 @@ func TestValidateCloudGraphQuery(t *testing.T) {
 			true,
 		},
 		{
+			"private source IP set",
+			args{
+				"invalid",
+				&CloudNetworkQuery{
+					SourceIP: "10.1.1.0/24",
+					DestinationSelector: &CloudNetworkQueryFilter{
+						VPCIDs: []string{"vpc1"},
+					},
+				},
+			},
+			true,
+		},
+		{
 			"source ip and selector set",
 			args{
 				"invalid",
@@ -4107,6 +4120,19 @@ func TestValidateCloudGraphQuery(t *testing.T) {
 				"invalid",
 				&CloudNetworkQuery{
 					SourceIP: "0.0.0.0/0",
+				},
+			},
+			true,
+		},
+		{
+			"private destination IP",
+			args{
+				"invalid",
+				&CloudNetworkQuery{
+					DestinationIP: "10.1.1.0/24",
+					SourceSelector: &CloudNetworkQueryFilter{
+						VPCIDs: []string{"vpc1"},
+					},
 				},
 			},
 			true,
@@ -4201,6 +4227,43 @@ func TestValidateCloudGraphQuery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := ValidateCloudNetworkQueryEntity(tt.args.query); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateCloudNetworkQueryEntity() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsAddressPrivate(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		args    string
+		want    bool
+		wantErr bool
+	}{
+		{
+			"private address",
+			"127.0.0.0/10",
+			true,
+			false,
+		},
+		{
+			"public address",
+			"135.20.0.0/24",
+			false,
+			false,
+		},
+		{
+			"public address",
+			"badIP",
+			false,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if private, err := IsAddressPrivate(tt.args); (private != tt.want) || (err == nil) == tt.wantErr {
+				t.Errorf("IsAddressPrivate() got wrong response %v for %+v with error %s", private, tt.args, err)
 			}
 		})
 	}

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -4266,38 +4266,6 @@ func TestValidateCloudGraphQuery(t *testing.T) {
 	}
 }
 
-func TestIsAddressPrivate(t *testing.T) {
-
-	tests := []struct {
-		name    string
-		args    string
-		want    bool
-		wantErr bool
-	}{
-		{
-			"private address",
-			"127.0.0.0/10",
-			true,
-			false,
-		},
-		{
-			"public address",
-			"135.20.0.0/24",
-			false,
-			false,
-		},
-		{
-			"public address",
-			"badIP",
-			false,
-			true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if private, err := IsAddressPrivate(tt.args); (private != tt.want) || (err == nil) == tt.wantErr {
-				t.Errorf("IsAddressPrivate() got wrong response %v for %+v with error %s", private, tt.args, err)
 func TestValidateIPAddressList(t *testing.T) {
 	type args struct {
 		attribute string
@@ -4355,6 +4323,7 @@ func TestValidateOptionalIPAddressList(t *testing.T) {
 		attribute string
 		ips       []string
 	}
+
 	tests := []struct {
 		name    string
 		args    args
@@ -4397,6 +4366,43 @@ func TestValidateOptionalIPAddressList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := ValidateOptionalIPAddressList(tt.args.attribute, tt.args.ips); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateOptionalIPAddressList() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsAddressPrivate(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		args    string
+		want    bool
+		wantErr bool
+	}{
+		{
+			"private address",
+			"127.0.0.0/10",
+			true,
+			false,
+		},
+		{
+			"public address",
+			"135.20.0.0/24",
+			false,
+			false,
+		},
+		{
+			"public address",
+			"badIP",
+			false,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if private, err := IsAddressPrivate(tt.args); (private != tt.want) || (err == nil) == tt.wantErr {
+				t.Errorf("IsAddressPrivate() got wrong response %v for %+v with error %s", private, tt.args, err)
 			}
 		})
 	}

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -9122,7 +9122,7 @@ interface.
 
 ##### `attachmentType` [`required`]
 
-Type: `enum(Instance | LoadBalancer | Gateway | Service | TransitGatewayVPCAttachment | NetworkLoadBalancer | Lambda | GatewayLoadBalancer | GatewayLoadBalancerEndpoint | VPCEndpoint | APIGatewayManaged | EFA)`
+Type: `enum(Instance | LoadBalancer | Gateway | Service | TransitGatewayVPCAttachment | NetworkLoadBalancer | Lambda | GatewayLoadBalancer | GatewayLoadBalancerEndpoint | VPCEndpoint | APIGatewayManaged | EFA | UnsupportedService)`
 
 Attachment type describes where this interface is attached to (Instance, Load
 Balancer, Gateway, etc).

--- a/specs/+cloudinterfacedata.spec
+++ b/specs/+cloudinterfacedata.spec
@@ -43,6 +43,7 @@ attributes:
     - VPCEndpoint
     - APIGatewayManaged
     - EFA
+    - UnsupportedService
     example_value: Instance
 
   - name: relatedObjectID


### PR DESCRIPTION
Adds new type of interface (Unsupported) since AWS can send us anything there. We just mark it as unsupported.

Adds a set of validations so that source/destination IPs cannot be private IP addresses.