### PR TITLE
Add children IDs to cloud graph output

### DIFF
--- a/cloudgraphnode.go
+++ b/cloudgraphnode.go
@@ -10,6 +10,9 @@ import (
 
 // CloudGraphNode represents the model of a cloudgraphnode
 type CloudGraphNode struct {
+	// The list of children for this node.
+	ChildrenIDs []string `json:"childrenIDs,omitempty" msgpack:"childrenIDs,omitempty" bson:"-" mapstructure:"childrenIDs,omitempty"`
+
 	// The native ID of the node.
 	NativeID string `json:"nativeID,omitempty" msgpack:"nativeID,omitempty" bson:"-" mapstructure:"nativeID,omitempty"`
 
@@ -18,6 +21,9 @@ type CloudGraphNode struct {
 
 	// The policies that were applied to this node for each destination.
 	Policies map[string]*CloudGraphNodeAction `json:"policies,omitempty" msgpack:"policies,omitempty" bson:"-" mapstructure:"policies,omitempty"`
+
+	// The list of children for this node.
+	PublicChildrenIDs []string `json:"publicChildrenIDs,omitempty" msgpack:"publicChildrenIDs,omitempty" bson:"-" mapstructure:"publicChildrenIDs,omitempty"`
 
 	// The list of route tables IDs that forwarding was based on for the internal path,
 	// if routing was
@@ -34,10 +40,12 @@ type CloudGraphNode struct {
 func NewCloudGraphNode() *CloudGraphNode {
 
 	return &CloudGraphNode{
-		ModelVersion:  1,
-		NodeData:      NewCloudNode(),
-		Policies:      map[string]*CloudGraphNodeAction{},
-		RouteTableIDs: map[string]string{},
+		ModelVersion:      1,
+		ChildrenIDs:       []string{},
+		NodeData:          NewCloudNode(),
+		Policies:          map[string]*CloudGraphNodeAction{},
+		PublicChildrenIDs: []string{},
+		RouteTableIDs:     map[string]string{},
 	}
 }
 

--- a/cloudgraphnode.go
+++ b/cloudgraphnode.go
@@ -11,7 +11,7 @@ import (
 // CloudGraphNode represents the model of a cloudgraphnode
 type CloudGraphNode struct {
 	// The list of children for this node.
-	ChildrenIDs []string `json:"childrenIDs,omitempty" msgpack:"childrenIDs,omitempty" bson:"-" mapstructure:"childrenIDs,omitempty"`
+	ChildrenIDs map[string][]string `json:"childrenIDs,omitempty" msgpack:"childrenIDs,omitempty" bson:"-" mapstructure:"childrenIDs,omitempty"`
 
 	// The native ID of the node.
 	NativeID string `json:"nativeID,omitempty" msgpack:"nativeID,omitempty" bson:"-" mapstructure:"nativeID,omitempty"`
@@ -22,8 +22,8 @@ type CloudGraphNode struct {
 	// The policies that were applied to this node for each destination.
 	Policies map[string]*CloudGraphNodeAction `json:"policies,omitempty" msgpack:"policies,omitempty" bson:"-" mapstructure:"policies,omitempty"`
 
-	// The list of children for this node.
-	PublicChildrenIDs []string `json:"publicChildrenIDs,omitempty" msgpack:"publicChildrenIDs,omitempty" bson:"-" mapstructure:"publicChildrenIDs,omitempty"`
+	// The list of public children for this node.
+	PublicChildrenIDs map[string][]string `json:"publicChildrenIDs,omitempty" msgpack:"publicChildrenIDs,omitempty" bson:"-" mapstructure:"publicChildrenIDs,omitempty"`
 
 	// The list of route tables IDs that forwarding was based on for the internal path,
 	// if routing was
@@ -41,10 +41,10 @@ func NewCloudGraphNode() *CloudGraphNode {
 
 	return &CloudGraphNode{
 		ModelVersion:      1,
-		ChildrenIDs:       []string{},
+		ChildrenIDs:       map[string][]string{},
 		NodeData:          NewCloudNode(),
 		Policies:          map[string]*CloudGraphNodeAction{},
-		PublicChildrenIDs: []string{},
+		PublicChildrenIDs: map[string][]string{},
 		RouteTableIDs:     map[string]string{},
 	}
 }

--- a/cloudgraphnode.go
+++ b/cloudgraphnode.go
@@ -11,10 +11,7 @@ import (
 // CloudGraphNode represents the model of a cloudgraphnode
 type CloudGraphNode struct {
 	// The list of children for this node.
-	ChildrenIDs map[string][]string `json:"childrenIDs,omitempty" msgpack:"childrenIDs,omitempty" bson:"-" mapstructure:"childrenIDs,omitempty"`
-
-	// The native ID of the node.
-	NativeID string `json:"nativeID,omitempty" msgpack:"nativeID,omitempty" bson:"-" mapstructure:"nativeID,omitempty"`
+	ChildrenIDs map[string]map[string][]string `json:"childrenIDs,omitempty" msgpack:"childrenIDs,omitempty" bson:"-" mapstructure:"childrenIDs,omitempty"`
 
 	// Details about the node if the query type requests full details.
 	NodeData *CloudNode `json:"nodeData,omitempty" msgpack:"nodeData,omitempty" bson:"-" mapstructure:"nodeData,omitempty"`
@@ -23,7 +20,7 @@ type CloudGraphNode struct {
 	Policies map[string]*CloudGraphNodeAction `json:"policies,omitempty" msgpack:"policies,omitempty" bson:"-" mapstructure:"policies,omitempty"`
 
 	// The list of public children for this node.
-	PublicChildrenIDs map[string][]string `json:"publicChildrenIDs,omitempty" msgpack:"publicChildrenIDs,omitempty" bson:"-" mapstructure:"publicChildrenIDs,omitempty"`
+	PublicChildrenIDs map[string]map[string][]string `json:"publicChildrenIDs,omitempty" msgpack:"publicChildrenIDs,omitempty" bson:"-" mapstructure:"publicChildrenIDs,omitempty"`
 
 	// The list of route tables IDs that forwarding was based on for the internal path,
 	// if routing was
@@ -41,10 +38,10 @@ func NewCloudGraphNode() *CloudGraphNode {
 
 	return &CloudGraphNode{
 		ModelVersion:      1,
-		ChildrenIDs:       map[string][]string{},
+		ChildrenIDs:       map[string]map[string][]string{},
 		NodeData:          NewCloudNode(),
 		Policies:          map[string]*CloudGraphNodeAction{},
-		PublicChildrenIDs: map[string][]string{},
+		PublicChildrenIDs: map[string]map[string][]string{},
 		RouteTableIDs:     map[string]string{},
 	}
 }

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -9045,15 +9045,9 @@ connections in a particular namespace.
 
 ##### `childrenIDs`
 
-Type: `map[string][]string`
+Type: `map[string]map[string][]string`
 
 The list of children for this node.
-
-##### `nativeID`
-
-Type: `string`
-
-The native ID of the node.
 
 ##### `nodeData`
 
@@ -9069,7 +9063,7 @@ The policies that were applied to this node for each destination.
 
 ##### `publicChildrenIDs`
 
-Type: `map[string][]string`
+Type: `map[string]map[string][]string`
 
 The list of public children for this node.
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -9045,7 +9045,7 @@ connections in a particular namespace.
 
 ##### `childrenIDs`
 
-Type: `[]string`
+Type: `map[string][]string`
 
 The list of children for this node.
 
@@ -9069,9 +9069,9 @@ The policies that were applied to this node for each destination.
 
 ##### `publicChildrenIDs`
 
-Type: `[]string`
+Type: `map[string][]string`
 
-The list of children for this node.
+The list of public children for this node.
 
 ##### `routeTableIDs`
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -9043,6 +9043,12 @@ connections in a particular namespace.
 
 #### Attributes
 
+##### `childrenIDs`
+
+Type: `[]string`
+
+The list of children for this node.
+
 ##### `nativeID`
 
 Type: `string`
@@ -9060,6 +9066,12 @@ Details about the node if the query type requests full details.
 Type: [`map[string]cloudgraphnodeaction`](#cloudgraphnodeaction)
 
 The policies that were applied to this node for each destination.
+
+##### `publicChildrenIDs`
+
+Type: `[]string`
+
+The list of children for this node.
 
 ##### `routeTableIDs`
 

--- a/specs/+cloudgraphnode.spec
+++ b/specs/+cloudgraphnode.spec
@@ -13,6 +13,13 @@ model:
 # Attributes
 attributes:
   v1:
+  - name: childrenIDs
+    description: The list of children for this node.
+    type: list
+    exposed: true
+    subtype: string
+    omit_empty: true
+
   - name: nativeID
     description: The native ID of the node.
     type: string
@@ -36,6 +43,13 @@ attributes:
     omit_empty: true
     extensions:
       refMode: pointer
+
+  - name: publicChildrenIDs
+    description: The list of children for this node.
+    type: list
+    exposed: true
+    subtype: string
+    omit_empty: true
 
   - name: routeTableIDs
     description: |-

--- a/specs/+cloudgraphnode.spec
+++ b/specs/+cloudgraphnode.spec
@@ -17,13 +17,7 @@ attributes:
     description: The list of children for this node.
     type: external
     exposed: true
-    subtype: map[string][]string
-    omit_empty: true
-
-  - name: nativeID
-    description: The native ID of the node.
-    type: string
-    exposed: true
+    subtype: map[string]map[string][]string
     omit_empty: true
 
   - name: nodeData
@@ -48,7 +42,7 @@ attributes:
     description: The list of public children for this node.
     type: external
     exposed: true
-    subtype: map[string][]string
+    subtype: map[string]map[string][]string
     omit_empty: true
 
   - name: routeTableIDs

--- a/specs/+cloudgraphnode.spec
+++ b/specs/+cloudgraphnode.spec
@@ -15,9 +15,9 @@ attributes:
   v1:
   - name: childrenIDs
     description: The list of children for this node.
-    type: list
+    type: external
     exposed: true
-    subtype: string
+    subtype: map[string][]string
     omit_empty: true
 
   - name: nativeID
@@ -45,10 +45,10 @@ attributes:
       refMode: pointer
 
   - name: publicChildrenIDs
-    description: The list of children for this node.
-    type: list
+    description: The list of public children for this node.
+    type: external
     exposed: true
-    subtype: string
+    subtype: map[string][]string
     omit_empty: true
 
   - name: routeTableIDs

--- a/specs/_type.mapping
+++ b/specs/_type.mapping
@@ -333,6 +333,25 @@ map[string]interface{}:
         "additionalProperties": true
       }
 
+map[string]map[string][]string:
+  elemental:
+    type: map[string]map[string][]string
+    init: map[string]map[string][]string{}
+  jsonschema:
+    type: |-
+      {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+
 map[string]map[string]bool:
   elemental:
     type: map[string]map[string]bool


### PR DESCRIPTION
Adds the children IDs for every node in the graph output