### PR TITLE
new: remote policy ID in flowreport

### DIFF
--- a/cachedflowreport.go
+++ b/cachedflowreport.go
@@ -232,6 +232,9 @@ type CachedFlowReport struct {
 	// Namespace of the object at the other end of the flow.
 	RemoteNamespace string `json:"remoteNamespace,omitempty" msgpack:"remoteNamespace,omitempty" bson:"u,omitempty" mapstructure:"remoteNamespace,omitempty"`
 
+	// ID of the network policy that accepted the flow at the remote endpoint.
+	RemotePolicyID string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ai,omitempty" mapstructure:"remotePolicyID,omitempty"`
+
 	// Contains the eventual name assigned to the particular rule in the
 	// NetworkRuleSetPolicy that acted on the flow.
 	RuleName string `json:"ruleName,omitempty" msgpack:"ruleName,omitempty" bson:"ba,omitempty" mapstructure:"ruleName,omitempty"`
@@ -291,9 +294,9 @@ func NewCachedFlowReport() *CachedFlowReport {
 
 	return &CachedFlowReport{
 		ModelVersion:   1,
-		MigrationsLog:  map[string]string{},
-		ServiceType:    CachedFlowReportServiceTypeNotApplicable,
 		ObservedAction: CachedFlowReportObservedActionNotApplicable,
+		ServiceType:    CachedFlowReportServiceTypeNotApplicable,
+		MigrationsLog:  map[string]string{},
 	}
 }
 
@@ -353,6 +356,7 @@ func (o *CachedFlowReport) GetBSON() (interface{}, error) {
 	s.PolicyNamespace = o.PolicyNamespace
 	s.Protocol = o.Protocol
 	s.RemoteNamespace = o.RemoteNamespace
+	s.RemotePolicyID = o.RemotePolicyID
 	s.RuleName = o.RuleName
 	s.ServiceClaimHash = o.ServiceClaimHash
 	s.ServiceID = o.ServiceID
@@ -412,6 +416,7 @@ func (o *CachedFlowReport) SetBSON(raw bson.Raw) error {
 	o.PolicyNamespace = s.PolicyNamespace
 	o.Protocol = s.Protocol
 	o.RemoteNamespace = s.RemoteNamespace
+	o.RemotePolicyID = s.RemotePolicyID
 	o.RuleName = s.RuleName
 	o.ServiceClaimHash = s.ServiceClaimHash
 	o.ServiceID = s.ServiceID
@@ -530,6 +535,7 @@ func (o *CachedFlowReport) ToSparse(fields ...string) elemental.SparseIdentifiab
 			PolicyNamespace:         &o.PolicyNamespace,
 			Protocol:                &o.Protocol,
 			RemoteNamespace:         &o.RemoteNamespace,
+			RemotePolicyID:          &o.RemotePolicyID,
 			RuleName:                &o.RuleName,
 			ServiceClaimHash:        &o.ServiceClaimHash,
 			ServiceID:               &o.ServiceID,
@@ -604,6 +610,8 @@ func (o *CachedFlowReport) ToSparse(fields ...string) elemental.SparseIdentifiab
 			sp.Protocol = &(o.Protocol)
 		case "remoteNamespace":
 			sp.RemoteNamespace = &(o.RemoteNamespace)
+		case "remotePolicyID":
+			sp.RemotePolicyID = &(o.RemotePolicyID)
 		case "ruleName":
 			sp.RuleName = &(o.RuleName)
 		case "serviceClaimHash":
@@ -726,6 +734,9 @@ func (o *CachedFlowReport) Patch(sparse elemental.SparseIdentifiable) {
 	}
 	if so.RemoteNamespace != nil {
 		o.RemoteNamespace = *so.RemoteNamespace
+	}
+	if so.RemotePolicyID != nil {
+		o.RemotePolicyID = *so.RemotePolicyID
 	}
 	if so.RuleName != nil {
 		o.RuleName = *so.RuleName
@@ -954,6 +965,8 @@ func (o *CachedFlowReport) ValueForAttribute(name string) interface{} {
 		return o.Protocol
 	case "remoteNamespace":
 		return o.RemoteNamespace
+	case "remotePolicyID":
+		return o.RemotePolicyID
 	case "ruleName":
 		return o.RuleName
 	case "serviceClaimHash":
@@ -1269,6 +1282,16 @@ to ` + "`" + `Reject` + "`" + `.`,
 		Description:    `Namespace of the object at the other end of the flow.`,
 		Exposed:        true,
 		Name:           "remoteNamespace",
+		Stored:         true,
+		Type:           "string",
+	},
+	"RemotePolicyID": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "ai",
+		ConvertedName:  "RemotePolicyID",
+		Description:    `ID of the network policy that accepted the flow at the remote endpoint.`,
+		Exposed:        true,
+		Name:           "remotePolicyID",
 		Stored:         true,
 		Type:           "string",
 	},
@@ -1731,6 +1754,16 @@ to ` + "`" + `Reject` + "`" + `.`,
 		Stored:         true,
 		Type:           "string",
 	},
+	"remotepolicyid": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "ai",
+		ConvertedName:  "RemotePolicyID",
+		Description:    `ID of the network policy that accepted the flow at the remote endpoint.`,
+		Exposed:        true,
+		Name:           "remotePolicyID",
+		Stored:         true,
+		Type:           "string",
+	},
 	"rulename": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "ba",
@@ -2053,6 +2086,9 @@ type SparseCachedFlowReport struct {
 	// Namespace of the object at the other end of the flow.
 	RemoteNamespace *string `json:"remoteNamespace,omitempty" msgpack:"remoteNamespace,omitempty" bson:"u,omitempty" mapstructure:"remoteNamespace,omitempty"`
 
+	// ID of the network policy that accepted the flow at the remote endpoint.
+	RemotePolicyID *string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ai,omitempty" mapstructure:"remotePolicyID,omitempty"`
+
 	// Contains the eventual name assigned to the particular rule in the
 	// NetworkRuleSetPolicy that acted on the flow.
 	RuleName *string `json:"ruleName,omitempty" msgpack:"ruleName,omitempty" bson:"ba,omitempty" mapstructure:"ruleName,omitempty"`
@@ -2225,6 +2261,9 @@ func (o *SparseCachedFlowReport) GetBSON() (interface{}, error) {
 	if o.RemoteNamespace != nil {
 		s.RemoteNamespace = o.RemoteNamespace
 	}
+	if o.RemotePolicyID != nil {
+		s.RemotePolicyID = o.RemotePolicyID
+	}
 	if o.RuleName != nil {
 		s.RuleName = o.RuleName
 	}
@@ -2367,6 +2406,9 @@ func (o *SparseCachedFlowReport) SetBSON(raw bson.Raw) error {
 	if s.RemoteNamespace != nil {
 		o.RemoteNamespace = s.RemoteNamespace
 	}
+	if s.RemotePolicyID != nil {
+		o.RemotePolicyID = s.RemotePolicyID
+	}
 	if s.RuleName != nil {
 		o.RuleName = s.RuleName
 	}
@@ -2506,6 +2548,9 @@ func (o *SparseCachedFlowReport) ToPlain() elemental.PlainIdentifiable {
 	}
 	if o.RemoteNamespace != nil {
 		out.RemoteNamespace = *o.RemoteNamespace
+	}
+	if o.RemotePolicyID != nil {
+		out.RemotePolicyID = *o.RemotePolicyID
 	}
 	if o.RuleName != nil {
 		out.RuleName = *o.RuleName
@@ -2658,6 +2703,7 @@ type mongoAttributesCachedFlowReport struct {
 	PolicyNamespace         string                               `bson:"s,omitempty"`
 	Protocol                int                                  `bson:"t,omitempty"`
 	RemoteNamespace         string                               `bson:"u,omitempty"`
+	RemotePolicyID          string                               `bson:"ai,omitempty"`
 	RuleName                string                               `bson:"ba,omitempty"`
 	ServiceClaimHash        string                               `bson:"v,omitempty"`
 	ServiceID               string                               `bson:"w,omitempty"`
@@ -2702,6 +2748,7 @@ type mongoAttributesSparseCachedFlowReport struct {
 	PolicyNamespace         *string                               `bson:"s,omitempty"`
 	Protocol                *int                                  `bson:"t,omitempty"`
 	RemoteNamespace         *string                               `bson:"u,omitempty"`
+	RemotePolicyID          *string                               `bson:"ai,omitempty"`
 	RuleName                *string                               `bson:"ba,omitempty"`
 	ServiceClaimHash        *string                               `bson:"v,omitempty"`
 	ServiceID               *string                               `bson:"w,omitempty"`

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -14804,6 +14804,12 @@ Type: `string`
 
 Namespace of the object at the other end of the flow.
 
+##### `remotePolicyID`
+
+Type: `string`
+
+ID of the network policy that accepted the flow at the remote endpoint.
+
 ##### `ruleName`
 
 Type: `string`
@@ -15491,6 +15497,12 @@ Protocol number.
 Type: `string`
 
 Namespace of the object at the other end of the flow.
+
+##### `remotePolicyID`
+
+Type: `string`
+
+ID of the network policy that accepted the flow at the remote endpoint.
 
 ##### `ruleName`
 

--- a/flowreport.go
+++ b/flowreport.go
@@ -228,6 +228,9 @@ type FlowReport struct {
 	// Namespace of the object at the other end of the flow.
 	RemoteNamespace string `json:"remoteNamespace,omitempty" msgpack:"remoteNamespace,omitempty" bson:"u,omitempty" mapstructure:"remoteNamespace,omitempty"`
 
+	// ID of the network policy that accepted the flow at the remote endpoint.
+	RemotePolicyID string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ai,omitempty" mapstructure:"remotePolicyID,omitempty"`
+
 	// Contains the eventual name assigned to the particular rule in the
 	// NetworkRuleSetPolicy that acted on the flow.
 	RuleName string `json:"ruleName,omitempty" msgpack:"ruleName,omitempty" bson:"ba,omitempty" mapstructure:"ruleName,omitempty"`
@@ -287,9 +290,9 @@ func NewFlowReport() *FlowReport {
 
 	return &FlowReport{
 		ModelVersion:   1,
-		MigrationsLog:  map[string]string{},
-		ServiceType:    FlowReportServiceTypeNotApplicable,
 		ObservedAction: FlowReportObservedActionNotApplicable,
+		ServiceType:    FlowReportServiceTypeNotApplicable,
+		MigrationsLog:  map[string]string{},
 	}
 }
 
@@ -347,6 +350,7 @@ func (o *FlowReport) GetBSON() (interface{}, error) {
 	s.PolicyNamespace = o.PolicyNamespace
 	s.Protocol = o.Protocol
 	s.RemoteNamespace = o.RemoteNamespace
+	s.RemotePolicyID = o.RemotePolicyID
 	s.RuleName = o.RuleName
 	s.ServiceClaimHash = o.ServiceClaimHash
 	s.ServiceID = o.ServiceID
@@ -404,6 +408,7 @@ func (o *FlowReport) SetBSON(raw bson.Raw) error {
 	o.PolicyNamespace = s.PolicyNamespace
 	o.Protocol = s.Protocol
 	o.RemoteNamespace = s.RemoteNamespace
+	o.RemotePolicyID = s.RemotePolicyID
 	o.RuleName = s.RuleName
 	o.ServiceClaimHash = s.ServiceClaimHash
 	o.ServiceID = s.ServiceID
@@ -522,6 +527,7 @@ func (o *FlowReport) ToSparse(fields ...string) elemental.SparseIdentifiable {
 			PolicyNamespace:         &o.PolicyNamespace,
 			Protocol:                &o.Protocol,
 			RemoteNamespace:         &o.RemoteNamespace,
+			RemotePolicyID:          &o.RemotePolicyID,
 			RuleName:                &o.RuleName,
 			ServiceClaimHash:        &o.ServiceClaimHash,
 			ServiceID:               &o.ServiceID,
@@ -592,6 +598,8 @@ func (o *FlowReport) ToSparse(fields ...string) elemental.SparseIdentifiable {
 			sp.Protocol = &(o.Protocol)
 		case "remoteNamespace":
 			sp.RemoteNamespace = &(o.RemoteNamespace)
+		case "remotePolicyID":
+			sp.RemotePolicyID = &(o.RemotePolicyID)
 		case "ruleName":
 			sp.RuleName = &(o.RuleName)
 		case "serviceClaimHash":
@@ -708,6 +716,9 @@ func (o *FlowReport) Patch(sparse elemental.SparseIdentifiable) {
 	}
 	if so.RemoteNamespace != nil {
 		o.RemoteNamespace = *so.RemoteNamespace
+	}
+	if so.RemotePolicyID != nil {
+		o.RemotePolicyID = *so.RemotePolicyID
 	}
 	if so.RuleName != nil {
 		o.RuleName = *so.RuleName
@@ -927,6 +938,8 @@ func (o *FlowReport) ValueForAttribute(name string) interface{} {
 		return o.Protocol
 	case "remoteNamespace":
 		return o.RemoteNamespace
+	case "remotePolicyID":
+		return o.RemotePolicyID
 	case "ruleName":
 		return o.RuleName
 	case "serviceClaimHash":
@@ -1222,6 +1235,16 @@ to ` + "`" + `Reject` + "`" + `.`,
 		Description:    `Namespace of the object at the other end of the flow.`,
 		Exposed:        true,
 		Name:           "remoteNamespace",
+		Stored:         true,
+		Type:           "string",
+	},
+	"RemotePolicyID": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "ai",
+		ConvertedName:  "RemotePolicyID",
+		Description:    `ID of the network policy that accepted the flow at the remote endpoint.`,
+		Exposed:        true,
+		Name:           "remotePolicyID",
 		Stored:         true,
 		Type:           "string",
 	},
@@ -1664,6 +1687,16 @@ to ` + "`" + `Reject` + "`" + `.`,
 		Stored:         true,
 		Type:           "string",
 	},
+	"remotepolicyid": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "ai",
+		ConvertedName:  "RemotePolicyID",
+		Description:    `ID of the network policy that accepted the flow at the remote endpoint.`,
+		Exposed:        true,
+		Name:           "remotePolicyID",
+		Stored:         true,
+		Type:           "string",
+	},
 	"rulename": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "ba",
@@ -1982,6 +2015,9 @@ type SparseFlowReport struct {
 	// Namespace of the object at the other end of the flow.
 	RemoteNamespace *string `json:"remoteNamespace,omitempty" msgpack:"remoteNamespace,omitempty" bson:"u,omitempty" mapstructure:"remoteNamespace,omitempty"`
 
+	// ID of the network policy that accepted the flow at the remote endpoint.
+	RemotePolicyID *string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ai,omitempty" mapstructure:"remotePolicyID,omitempty"`
+
 	// Contains the eventual name assigned to the particular rule in the
 	// NetworkRuleSetPolicy that acted on the flow.
 	RuleName *string `json:"ruleName,omitempty" msgpack:"ruleName,omitempty" bson:"ba,omitempty" mapstructure:"ruleName,omitempty"`
@@ -2148,6 +2184,9 @@ func (o *SparseFlowReport) GetBSON() (interface{}, error) {
 	if o.RemoteNamespace != nil {
 		s.RemoteNamespace = o.RemoteNamespace
 	}
+	if o.RemotePolicyID != nil {
+		s.RemotePolicyID = o.RemotePolicyID
+	}
 	if o.RuleName != nil {
 		s.RuleName = o.RuleName
 	}
@@ -2284,6 +2323,9 @@ func (o *SparseFlowReport) SetBSON(raw bson.Raw) error {
 	if s.RemoteNamespace != nil {
 		o.RemoteNamespace = s.RemoteNamespace
 	}
+	if s.RemotePolicyID != nil {
+		o.RemotePolicyID = s.RemotePolicyID
+	}
 	if s.RuleName != nil {
 		o.RuleName = s.RuleName
 	}
@@ -2417,6 +2459,9 @@ func (o *SparseFlowReport) ToPlain() elemental.PlainIdentifiable {
 	}
 	if o.RemoteNamespace != nil {
 		out.RemoteNamespace = *o.RemoteNamespace
+	}
+	if o.RemotePolicyID != nil {
+		out.RemotePolicyID = *o.RemotePolicyID
 	}
 	if o.RuleName != nil {
 		out.RuleName = *o.RuleName
@@ -2567,6 +2612,7 @@ type mongoAttributesFlowReport struct {
 	PolicyNamespace         string                         `bson:"s,omitempty"`
 	Protocol                int                            `bson:"t,omitempty"`
 	RemoteNamespace         string                         `bson:"u,omitempty"`
+	RemotePolicyID          string                         `bson:"ai,omitempty"`
 	RuleName                string                         `bson:"ba,omitempty"`
 	ServiceClaimHash        string                         `bson:"v,omitempty"`
 	ServiceID               string                         `bson:"w,omitempty"`
@@ -2609,6 +2655,7 @@ type mongoAttributesSparseFlowReport struct {
 	PolicyNamespace         *string                         `bson:"s,omitempty"`
 	Protocol                *int                            `bson:"t,omitempty"`
 	RemoteNamespace         *string                         `bson:"u,omitempty"`
+	RemotePolicyID          *string                         `bson:"ai,omitempty"`
 	RuleName                *string                         `bson:"ba,omitempty"`
 	ServiceClaimHash        *string                         `bson:"v,omitempty"`
 	ServiceID               *string                         `bson:"w,omitempty"`

--- a/specs/@flow.abs
+++ b/specs/@flow.abs
@@ -229,7 +229,6 @@ attributes:
     type: integer
     exposed: true
     stored: true
-    required: false
     example_value: 6
     omit_empty: true
     extensions:
@@ -243,6 +242,15 @@ attributes:
     omit_empty: true
     extensions:
       bson_name: u
+
+  - name: remotePolicyID
+    description: ID of the network policy that accepted the flow at the remote endpoint.
+    type: string
+    exposed: true
+    stored: true
+    omit_empty: true
+    extensions:
+      bson_name: ai
 
   - name: ruleName
     description: |-


### PR DESCRIPTION
https://redlock.atlassian.net/browse/CNS-2350

--- 

### Problem:

Our datapath model is doing mutual auth, which means during the process we validate the policy on both client and server side. Right now we report the policy ID at the endpoint where we decide to accept/drop the packet. The goal is to report the policy ID being validated at the remote end.

### Field(s):

`remotePolicyID` - ID of the network policy that accepted the flow at the remote endpoint. Unfortunately, we cant add `remotePolicyNamespace` at the moment but having this partial info will atleast let us know that there are 2 policies being validated during our auth process.


Endpoint | Action | NetworkState | Fields 
-- | -- | -- | -- 
Server | Reject | Syn | N/A 
Client | Reject | SynAck | remotePolicyID == Destination PolicyID
Server | Accept | Ack | remotePolicyID == Source PolicyID

</div></b>

For more details refer, https://docs.google.com/document/d/1tBui61SakfRVHmS8gkrwfYNJX-HLN6YKeKTUmg7iaIs/edit?usp=sharing