### PR TITLE
Add excluded networks and services

### DIFF
--- a/cloudnetworkquery.go
+++ b/cloudnetworkquery.go
@@ -143,6 +143,10 @@ type CloudNetworkQuery struct {
 	// permissions.
 	ExcludeEnterpriseIPs bool `json:"excludeEnterpriseIPs" msgpack:"excludeEnterpriseIPs" bson:"excludeenterpriseips" mapstructure:"excludeEnterpriseIPs,omitempty"`
 
+	// List of networks that should be a excluded from the calculation if the source or
+	// destination is a network.
+	ExcludedNetworks []string `json:"excludedNetworks" msgpack:"excludedNetworks" bson:"excludednetworks" mapstructure:"excludedNetworks,omitempty"`
+
 	// Internal property maintaining migrations information.
 	MigrationsLog map[string]string `json:"-" msgpack:"-" bson:"migrationslog,omitempty" mapstructure:"-,omitempty"`
 
@@ -197,6 +201,7 @@ func NewCloudNetworkQuery() *CloudNetworkQuery {
 		Annotations:         map[string][]string{},
 		DestinationSelector: NewCloudNetworkQueryFilter(),
 		AssociatedTags:      []string{},
+		ExcludedNetworks:    []string{},
 		EffectiveAction:     CloudNetworkQueryEffectiveActionReachableOnly,
 		NormalizedTags:      []string{},
 		ProtocolPorts:       []string{},
@@ -245,6 +250,7 @@ func (o *CloudNetworkQuery) GetBSON() (interface{}, error) {
 	s.DestinationSelector = o.DestinationSelector
 	s.EffectiveAction = o.EffectiveAction
 	s.ExcludeEnterpriseIPs = o.ExcludeEnterpriseIPs
+	s.ExcludedNetworks = o.ExcludedNetworks
 	s.MigrationsLog = o.MigrationsLog
 	s.Name = o.Name
 	s.Namespace = o.Namespace
@@ -284,6 +290,7 @@ func (o *CloudNetworkQuery) SetBSON(raw bson.Raw) error {
 	o.DestinationSelector = s.DestinationSelector
 	o.EffectiveAction = s.EffectiveAction
 	o.ExcludeEnterpriseIPs = s.ExcludeEnterpriseIPs
+	o.ExcludedNetworks = s.ExcludedNetworks
 	o.MigrationsLog = s.MigrationsLog
 	o.Name = s.Name
 	o.Namespace = s.Namespace
@@ -492,6 +499,7 @@ func (o *CloudNetworkQuery) ToSparse(fields ...string) elemental.SparseIdentifia
 			DestinationSelector:  o.DestinationSelector,
 			EffectiveAction:      &o.EffectiveAction,
 			ExcludeEnterpriseIPs: &o.ExcludeEnterpriseIPs,
+			ExcludedNetworks:     &o.ExcludedNetworks,
 			MigrationsLog:        &o.MigrationsLog,
 			Name:                 &o.Name,
 			Namespace:            &o.Namespace,
@@ -529,6 +537,8 @@ func (o *CloudNetworkQuery) ToSparse(fields ...string) elemental.SparseIdentifia
 			sp.EffectiveAction = &(o.EffectiveAction)
 		case "excludeEnterpriseIPs":
 			sp.ExcludeEnterpriseIPs = &(o.ExcludeEnterpriseIPs)
+		case "excludedNetworks":
+			sp.ExcludedNetworks = &(o.ExcludedNetworks)
 		case "migrationsLog":
 			sp.MigrationsLog = &(o.MigrationsLog)
 		case "name":
@@ -594,6 +604,9 @@ func (o *CloudNetworkQuery) Patch(sparse elemental.SparseIdentifiable) {
 	}
 	if so.ExcludeEnterpriseIPs != nil {
 		o.ExcludeEnterpriseIPs = *so.ExcludeEnterpriseIPs
+	}
+	if so.ExcludedNetworks != nil {
+		o.ExcludedNetworks = *so.ExcludedNetworks
 	}
 	if so.MigrationsLog != nil {
 		o.MigrationsLog = *so.MigrationsLog
@@ -689,6 +702,10 @@ func (o *CloudNetworkQuery) Validate() error {
 		errors = errors.Append(err)
 	}
 
+	if err := ValidateOptionalCIDRorIPList("excludedNetworks", o.ExcludedNetworks); err != nil {
+		errors = errors.Append(err)
+	}
+
 	if err := elemental.ValidateRequiredString("name", o.Name); err != nil {
 		requiredErrors = requiredErrors.Append(err)
 	}
@@ -773,6 +790,8 @@ func (o *CloudNetworkQuery) ValueForAttribute(name string) interface{} {
 		return o.EffectiveAction
 	case "excludeEnterpriseIPs":
 		return o.ExcludeEnterpriseIPs
+	case "excludedNetworks":
+		return o.ExcludedNetworks
 	case "migrationsLog":
 		return o.MigrationsLog
 	case "name":
@@ -921,6 +940,18 @@ permissions.`,
 		Name:    "excludeEnterpriseIPs",
 		Stored:  true,
 		Type:    "boolean",
+	},
+	"ExcludedNetworks": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "excludednetworks",
+		ConvertedName:  "ExcludedNetworks",
+		Description: `List of networks that should be a excluded from the calculation if the source or
+destination is a network.`,
+		Exposed: true,
+		Name:    "excludedNetworks",
+		Stored:  true,
+		SubType: "string",
+		Type:    "list",
 	},
 	"MigrationsLog": {
 		AllowedChoices: []string{},
@@ -1211,6 +1242,18 @@ permissions.`,
 		Stored:  true,
 		Type:    "boolean",
 	},
+	"excludednetworks": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "excludednetworks",
+		ConvertedName:  "ExcludedNetworks",
+		Description: `List of networks that should be a excluded from the calculation if the source or
+destination is a network.`,
+		Exposed: true,
+		Name:    "excludedNetworks",
+		Stored:  true,
+		SubType: "string",
+		Type:    "list",
+	},
 	"migrationslog": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "migrationslog",
@@ -1480,6 +1523,10 @@ type SparseCloudNetworkQuery struct {
 	// permissions.
 	ExcludeEnterpriseIPs *bool `json:"excludeEnterpriseIPs,omitempty" msgpack:"excludeEnterpriseIPs,omitempty" bson:"excludeenterpriseips,omitempty" mapstructure:"excludeEnterpriseIPs,omitempty"`
 
+	// List of networks that should be a excluded from the calculation if the source or
+	// destination is a network.
+	ExcludedNetworks *[]string `json:"excludedNetworks,omitempty" msgpack:"excludedNetworks,omitempty" bson:"excludednetworks,omitempty" mapstructure:"excludedNetworks,omitempty"`
+
 	// Internal property maintaining migrations information.
 	MigrationsLog *map[string]string `json:"-" msgpack:"-" bson:"migrationslog,omitempty" mapstructure:"-,omitempty"`
 
@@ -1593,6 +1640,9 @@ func (o *SparseCloudNetworkQuery) GetBSON() (interface{}, error) {
 	if o.ExcludeEnterpriseIPs != nil {
 		s.ExcludeEnterpriseIPs = o.ExcludeEnterpriseIPs
 	}
+	if o.ExcludedNetworks != nil {
+		s.ExcludedNetworks = o.ExcludedNetworks
+	}
 	if o.MigrationsLog != nil {
 		s.MigrationsLog = o.MigrationsLog
 	}
@@ -1675,6 +1725,9 @@ func (o *SparseCloudNetworkQuery) SetBSON(raw bson.Raw) error {
 	if s.ExcludeEnterpriseIPs != nil {
 		o.ExcludeEnterpriseIPs = s.ExcludeEnterpriseIPs
 	}
+	if s.ExcludedNetworks != nil {
+		o.ExcludedNetworks = s.ExcludedNetworks
+	}
 	if s.MigrationsLog != nil {
 		o.MigrationsLog = s.MigrationsLog
 	}
@@ -1754,6 +1807,9 @@ func (o *SparseCloudNetworkQuery) ToPlain() elemental.PlainIdentifiable {
 	}
 	if o.ExcludeEnterpriseIPs != nil {
 		out.ExcludeEnterpriseIPs = *o.ExcludeEnterpriseIPs
+	}
+	if o.ExcludedNetworks != nil {
+		out.ExcludedNetworks = *o.ExcludedNetworks
 	}
 	if o.MigrationsLog != nil {
 		out.MigrationsLog = *o.MigrationsLog
@@ -2024,6 +2080,7 @@ type mongoAttributesCloudNetworkQuery struct {
 	DestinationSelector  *CloudNetworkQueryFilter              `bson:"destinationselector"`
 	EffectiveAction      CloudNetworkQueryEffectiveActionValue `bson:"effectiveaction"`
 	ExcludeEnterpriseIPs bool                                  `bson:"excludeenterpriseips"`
+	ExcludedNetworks     []string                              `bson:"excludednetworks"`
 	MigrationsLog        map[string]string                     `bson:"migrationslog,omitempty"`
 	Name                 string                                `bson:"name"`
 	Namespace            string                                `bson:"namespace"`
@@ -2048,6 +2105,7 @@ type mongoAttributesSparseCloudNetworkQuery struct {
 	DestinationSelector  *CloudNetworkQueryFilter               `bson:"destinationselector,omitempty"`
 	EffectiveAction      *CloudNetworkQueryEffectiveActionValue `bson:"effectiveaction,omitempty"`
 	ExcludeEnterpriseIPs *bool                                  `bson:"excludeenterpriseips,omitempty"`
+	ExcludedNetworks     *[]string                              `bson:"excludednetworks,omitempty"`
 	MigrationsLog        *map[string]string                     `bson:"migrationslog,omitempty"`
 	Name                 *string                                `bson:"name,omitempty"`
 	Namespace            *string                                `bson:"namespace,omitempty"`

--- a/cloudnetworkqueryfilter.go
+++ b/cloudnetworkqueryfilter.go
@@ -65,6 +65,10 @@ type CloudNetworkQueryFilter struct {
 	// different meaning depending on the target cloud.
 	SecurityTags []string `json:"securityTags,omitempty" msgpack:"securityTags,omitempty" bson:"securitytags,omitempty" mapstructure:"securityTags,omitempty"`
 
+	// Identifies a list of service names that should be taken into account. This is
+	// only valid with a resource type equal to Service.
+	ServiceNames []string `json:"serviceNames,omitempty" msgpack:"serviceNames,omitempty" bson:"servicenames,omitempty" mapstructure:"serviceNames,omitempty"`
+
 	// Identifies the owner of the service that the resource is attached to. Field is
 	// not valid if the resource type is not an interface.
 	ServiceOwners []string `json:"serviceOwners,omitempty" msgpack:"serviceOwners,omitempty" bson:"serviceowners,omitempty" mapstructure:"serviceOwners,omitempty"`
@@ -94,12 +98,13 @@ func NewCloudNetworkQueryFilter() *CloudNetworkQueryFilter {
 		CloudTypes:    []string{},
 		ImageIDs:      []string{},
 		ObjectIDs:     []string{},
-		Subnets:       []string{},
+		ServiceOwners: []string{},
 		Regions:       []string{},
 		ResourceType:  CloudNetworkQueryFilterResourceTypeInstance,
 		SecurityTags:  []string{},
-		ServiceOwners: []string{},
+		ServiceNames:  []string{},
 		ServiceTypes:  []string{},
+		Subnets:       []string{},
 		Tags:          []string{},
 		VPCIDs:        []string{},
 	}
@@ -125,6 +130,7 @@ func (o *CloudNetworkQueryFilter) GetBSON() (interface{}, error) {
 	s.Regions = o.Regions
 	s.ResourceType = o.ResourceType
 	s.SecurityTags = o.SecurityTags
+	s.ServiceNames = o.ServiceNames
 	s.ServiceOwners = o.ServiceOwners
 	s.ServiceTypes = o.ServiceTypes
 	s.Subnets = o.Subnets
@@ -156,6 +162,7 @@ func (o *CloudNetworkQueryFilter) SetBSON(raw bson.Raw) error {
 	o.Regions = s.Regions
 	o.ResourceType = s.ResourceType
 	o.SecurityTags = s.SecurityTags
+	o.ServiceNames = s.ServiceNames
 	o.ServiceOwners = s.ServiceOwners
 	o.ServiceTypes = s.ServiceTypes
 	o.Subnets = s.Subnets
@@ -230,6 +237,7 @@ type mongoAttributesCloudNetworkQueryFilter struct {
 	Regions          []string                                 `bson:"regions,omitempty"`
 	ResourceType     CloudNetworkQueryFilterResourceTypeValue `bson:"resourcetype"`
 	SecurityTags     []string                                 `bson:"securitytags,omitempty"`
+	ServiceNames     []string                                 `bson:"servicenames,omitempty"`
 	ServiceOwners    []string                                 `bson:"serviceowners,omitempty"`
 	ServiceTypes     []string                                 `bson:"servicetypes,omitempty"`
 	Subnets          []string                                 `bson:"subnets,omitempty"`

--- a/custom_validations.go
+++ b/custom_validations.go
@@ -1380,6 +1380,10 @@ func ValidateCloudNetworkQueryEntity(q *CloudNetworkQuery) error {
 		}
 	}
 
+	if q.SourceIP == "" && q.DestinationIP == "" && len(q.ExcludedNetworks) != 0 {
+		return makeValidationError("Entity CloudNetworkQuery", "'excludedNetworks' is only valid when source or destination IP are defined")
+	}
+
 	emptyDestinationSelector := IsCloudNetworkQueryFilterEmpty(q.DestinationSelector)
 
 	if q.DestinationIP != "" && !emptyDestinationSelector {
@@ -1423,6 +1427,7 @@ func IsCloudNetworkQueryFilterEmpty(f *CloudNetworkQueryFilter) bool {
 		len(f.ServiceOwners) == 0 &&
 		len(f.ServiceTypes) == 0 &&
 		len(f.ImageIDs) == 0 &&
+		len(f.ServiceNames) == 0 &&
 		f.ProductInfoType == "" &&
 		f.ProductInfoValue == "" {
 		return true
@@ -1456,6 +1461,10 @@ func ValidateCloudNetworkQueryFilter(attribute string, f *CloudNetworkQueryFilte
 
 	if f.ResourceType != CloudNetworkQueryFilterResourceTypeInstance && f.ProductInfoValue != "" {
 		return makeValidationError(attribute, fmt.Sprintf("product value filtering only allowed for selectors with resource type: %s", CloudNetworkQueryFilterResourceTypeInstance))
+	}
+
+	if f.ResourceType != CloudNetworkQueryFilterResourceTypeService && len(f.ServiceNames) > 0 {
+		return makeValidationError(attribute, fmt.Sprintf("service name filtering only allowed for selectors with resource type: %s", CloudNetworkQueryFilterResourceTypeService))
 	}
 
 	return nil

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -4255,6 +4255,67 @@ func TestValidateCloudGraphQuery(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"service name as the selector",
+			args{
+				"valid",
+				&CloudNetworkQuery{
+					DestinationIP: "0.0.0.0/0",
+					SourceSelector: &CloudNetworkQueryFilter{
+						ResourceType: CloudNetworkQueryFilterResourceTypeService,
+						ServiceNames: []string{"service1"},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"service name as the selector when resource type is interface",
+			args{
+				"valid",
+				&CloudNetworkQuery{
+					DestinationIP: "0.0.0.0/0",
+					SourceSelector: &CloudNetworkQueryFilter{
+						ResourceType: CloudNetworkQueryFilterResourceTypeInterface,
+						ServiceNames: []string{"service1"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"excluded network validation with valid source",
+			args{
+				"valid",
+				&CloudNetworkQuery{
+					DestinationIP: "0.0.0.0/0",
+					SourceSelector: &CloudNetworkQueryFilter{
+						ResourceType: CloudNetworkQueryFilterResourceTypeService,
+						ServiceNames: []string{"service1"},
+					},
+					ExcludedNetworks: []string{"30.1.1.0/24"},
+				},
+			},
+			false,
+		},
+		{
+			"excluded network validation without IP definition",
+			args{
+				"valid",
+				&CloudNetworkQuery{
+					DestinationSelector: &CloudNetworkQueryFilter{
+						ResourceType: CloudNetworkQueryFilterResourceTypeService,
+						ServiceNames: []string{"service1"},
+					},
+					SourceSelector: &CloudNetworkQueryFilter{
+						ResourceType: CloudNetworkQueryFilterResourceTypeService,
+						ServiceNames: []string{"service1"},
+					},
+					ExcludedNetworks: []string{"30.1.1.0/24"},
+				},
+			},
+			true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -9803,6 +9803,13 @@ Type: `boolean`
 If set, the evaluation will exclude enterprise IPs from the effective
 permissions.
 
+##### `excludedNetworks`
+
+Type: `[]string`
+
+List of networks that should be a excluded from the calculation if the source or
+destination is a network.
+
 ##### `name` [`required`,`max_length=256`]
 
 Type: `string`
@@ -9993,6 +10000,13 @@ Type: `[]string`
 The list of security tags associated with the targets of the query. Security
 tags refer to security groups in AWS or network tags in GCP. So they can have
 different meaning depending on the target cloud.
+
+##### `serviceNames`
+
+Type: `[]string`
+
+Identifies a list of service names that should be taken into account. This is
+only valid with a resource type equal to Service.
 
 ##### `serviceOwners`
 

--- a/specs/+cloudnetworkqueryfilter.spec
+++ b/specs/+cloudnetworkqueryfilter.spec
@@ -116,6 +116,16 @@ attributes:
     stored: true
     omit_empty: true
 
+  - name: serviceNames
+    description: |-
+      Identifies a list of service names that should be taken into account. This is
+      only valid with a resource type equal to Service.
+    type: list
+    exposed: true
+    subtype: string
+    stored: true
+    omit_empty: true
+
   - name: serviceOwners
     description: |-
       Identifies the owner of the service that the resource is attached to. Field is

--- a/specs/cloudnetworkquery.spec
+++ b/specs/cloudnetworkquery.spec
@@ -71,6 +71,17 @@ attributes:
     exposed: true
     stored: true
 
+  - name: excludedNetworks
+    description: |-
+      List of networks that should be a excluded from the calculation if the source or
+      destination is a network.
+    type: list
+    exposed: true
+    subtype: string
+    stored: true
+    validations:
+    - $optionalcidroriplist
+
   - name: protocolPorts
     description: |-
       Represents the ports and protocols this policy applies to. Protocol/ports are


### PR DESCRIPTION
Adds new options for cloud network query:

1. Excluded Networks that are enterprise networks that should not be taken into account in the search.

2. ServiceNames and resource type of Service to allow queries for cloud services (VPC endpoints)
