### PR TITLE
fix: conflict in bson_name

### DIFF
--- a/cachedflowreport.go
+++ b/cachedflowreport.go
@@ -233,7 +233,7 @@ type CachedFlowReport struct {
 	RemoteNamespace string `json:"remoteNamespace,omitempty" msgpack:"remoteNamespace,omitempty" bson:"u,omitempty" mapstructure:"remoteNamespace,omitempty"`
 
 	// ID of the network policy that accepted the flow at the remote endpoint.
-	RemotePolicyID string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ai,omitempty" mapstructure:"remotePolicyID,omitempty"`
+	RemotePolicyID string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ak,omitempty" mapstructure:"remotePolicyID,omitempty"`
 
 	// Contains the eventual name assigned to the particular rule in the
 	// NetworkRuleSetPolicy that acted on the flow.
@@ -1287,7 +1287,7 @@ to ` + "`" + `Reject` + "`" + `.`,
 	},
 	"RemotePolicyID": {
 		AllowedChoices: []string{},
-		BSONFieldName:  "ai",
+		BSONFieldName:  "ak",
 		ConvertedName:  "RemotePolicyID",
 		Description:    `ID of the network policy that accepted the flow at the remote endpoint.`,
 		Exposed:        true,
@@ -1756,7 +1756,7 @@ to ` + "`" + `Reject` + "`" + `.`,
 	},
 	"remotepolicyid": {
 		AllowedChoices: []string{},
-		BSONFieldName:  "ai",
+		BSONFieldName:  "ak",
 		ConvertedName:  "RemotePolicyID",
 		Description:    `ID of the network policy that accepted the flow at the remote endpoint.`,
 		Exposed:        true,
@@ -2087,7 +2087,7 @@ type SparseCachedFlowReport struct {
 	RemoteNamespace *string `json:"remoteNamespace,omitempty" msgpack:"remoteNamespace,omitempty" bson:"u,omitempty" mapstructure:"remoteNamespace,omitempty"`
 
 	// ID of the network policy that accepted the flow at the remote endpoint.
-	RemotePolicyID *string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ai,omitempty" mapstructure:"remotePolicyID,omitempty"`
+	RemotePolicyID *string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ak,omitempty" mapstructure:"remotePolicyID,omitempty"`
 
 	// Contains the eventual name assigned to the particular rule in the
 	// NetworkRuleSetPolicy that acted on the flow.
@@ -2703,7 +2703,7 @@ type mongoAttributesCachedFlowReport struct {
 	PolicyNamespace         string                               `bson:"s,omitempty"`
 	Protocol                int                                  `bson:"t,omitempty"`
 	RemoteNamespace         string                               `bson:"u,omitempty"`
-	RemotePolicyID          string                               `bson:"ai,omitempty"`
+	RemotePolicyID          string                               `bson:"ak,omitempty"`
 	RuleName                string                               `bson:"ba,omitempty"`
 	ServiceClaimHash        string                               `bson:"v,omitempty"`
 	ServiceID               string                               `bson:"w,omitempty"`
@@ -2748,7 +2748,7 @@ type mongoAttributesSparseCachedFlowReport struct {
 	PolicyNamespace         *string                               `bson:"s,omitempty"`
 	Protocol                *int                                  `bson:"t,omitempty"`
 	RemoteNamespace         *string                               `bson:"u,omitempty"`
-	RemotePolicyID          *string                               `bson:"ai,omitempty"`
+	RemotePolicyID          *string                               `bson:"ak,omitempty"`
 	RuleName                *string                               `bson:"ba,omitempty"`
 	ServiceClaimHash        *string                               `bson:"v,omitempty"`
 	ServiceID               *string                               `bson:"w,omitempty"`

--- a/flowreport.go
+++ b/flowreport.go
@@ -229,7 +229,7 @@ type FlowReport struct {
 	RemoteNamespace string `json:"remoteNamespace,omitempty" msgpack:"remoteNamespace,omitempty" bson:"u,omitempty" mapstructure:"remoteNamespace,omitempty"`
 
 	// ID of the network policy that accepted the flow at the remote endpoint.
-	RemotePolicyID string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ai,omitempty" mapstructure:"remotePolicyID,omitempty"`
+	RemotePolicyID string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ak,omitempty" mapstructure:"remotePolicyID,omitempty"`
 
 	// Contains the eventual name assigned to the particular rule in the
 	// NetworkRuleSetPolicy that acted on the flow.
@@ -1240,7 +1240,7 @@ to ` + "`" + `Reject` + "`" + `.`,
 	},
 	"RemotePolicyID": {
 		AllowedChoices: []string{},
-		BSONFieldName:  "ai",
+		BSONFieldName:  "ak",
 		ConvertedName:  "RemotePolicyID",
 		Description:    `ID of the network policy that accepted the flow at the remote endpoint.`,
 		Exposed:        true,
@@ -1689,7 +1689,7 @@ to ` + "`" + `Reject` + "`" + `.`,
 	},
 	"remotepolicyid": {
 		AllowedChoices: []string{},
-		BSONFieldName:  "ai",
+		BSONFieldName:  "ak",
 		ConvertedName:  "RemotePolicyID",
 		Description:    `ID of the network policy that accepted the flow at the remote endpoint.`,
 		Exposed:        true,
@@ -2016,7 +2016,7 @@ type SparseFlowReport struct {
 	RemoteNamespace *string `json:"remoteNamespace,omitempty" msgpack:"remoteNamespace,omitempty" bson:"u,omitempty" mapstructure:"remoteNamespace,omitempty"`
 
 	// ID of the network policy that accepted the flow at the remote endpoint.
-	RemotePolicyID *string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ai,omitempty" mapstructure:"remotePolicyID,omitempty"`
+	RemotePolicyID *string `json:"remotePolicyID,omitempty" msgpack:"remotePolicyID,omitempty" bson:"ak,omitempty" mapstructure:"remotePolicyID,omitempty"`
 
 	// Contains the eventual name assigned to the particular rule in the
 	// NetworkRuleSetPolicy that acted on the flow.
@@ -2612,7 +2612,7 @@ type mongoAttributesFlowReport struct {
 	PolicyNamespace         string                         `bson:"s,omitempty"`
 	Protocol                int                            `bson:"t,omitempty"`
 	RemoteNamespace         string                         `bson:"u,omitempty"`
-	RemotePolicyID          string                         `bson:"ai,omitempty"`
+	RemotePolicyID          string                         `bson:"ak,omitempty"`
 	RuleName                string                         `bson:"ba,omitempty"`
 	ServiceClaimHash        string                         `bson:"v,omitempty"`
 	ServiceID               string                         `bson:"w,omitempty"`
@@ -2655,7 +2655,7 @@ type mongoAttributesSparseFlowReport struct {
 	PolicyNamespace         *string                         `bson:"s,omitempty"`
 	Protocol                *int                            `bson:"t,omitempty"`
 	RemoteNamespace         *string                         `bson:"u,omitempty"`
-	RemotePolicyID          *string                         `bson:"ai,omitempty"`
+	RemotePolicyID          *string                         `bson:"ak,omitempty"`
 	RuleName                *string                         `bson:"ba,omitempty"`
 	ServiceClaimHash        *string                         `bson:"v,omitempty"`
 	ServiceID               *string                         `bson:"w,omitempty"`

--- a/specs/@flow.abs
+++ b/specs/@flow.abs
@@ -250,7 +250,7 @@ attributes:
     stored: true
     omit_empty: true
     extensions:
-      bson_name: ai
+      bson_name: ak
 
   - name: ruleName
     description: |-


### PR DESCRIPTION
This fixes a conflict between `isLocalDestinationID` bson_name in `cachedflowreport.spec` and @flow.spec