### PR TITLE
Update: Allow zero port for service port validation

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -36,8 +36,8 @@ func ValidatePortString(attribute string, portExp string) error {
 		return makeValidationError(attribute, fmt.Sprintf("Attribute '%s' must be a port (xxx) or port range (xxx:yyy)", attribute))
 	}
 
-	if p1 < 1 || p1 > 65535 {
-		return makeValidationError(attribute, fmt.Sprintf("Attribute '%s' must be between 1 and 65535", attribute))
+	if p1 < 0 || p1 > 65535 {
+		return makeValidationError(attribute, fmt.Sprintf("Attribute '%s' must be between 0 and 65535", attribute))
 	}
 
 	if len(ports) == 1 {
@@ -49,8 +49,8 @@ func ValidatePortString(attribute string, portExp string) error {
 		return makeValidationError(attribute, fmt.Sprintf("Attribute '%s' must be a port (xxx) or port range (xxx:yyy)", attribute))
 	}
 
-	if p2 < 1 || p2 > 65535 {
-		return makeValidationError(attribute, fmt.Sprintf("Attribute '%s' must be between 1 and 65535", attribute))
+	if p2 < 0 || p2 > 65535 {
+		return makeValidationError(attribute, fmt.Sprintf("Attribute '%s' must be between 0 and 65535", attribute))
 	}
 
 	if p1 >= p2 {

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -43,10 +43,18 @@ func TestValidatePortString(t *testing.T) {
 			true,
 		},
 		{
-			"port set to 65536",
+			"port set to 0",
 			args{
 				"port",
 				"0",
+			},
+			false,
+		},
+		{
+			"port set to 65536",
+			args{
+				"port",
+				"65536",
 			},
 			true,
 		},
@@ -66,10 +74,10 @@ func TestValidatePortString(t *testing.T) {
 				"port",
 				"0:65535",
 			},
-			true,
+			false,
 		},
 		{
-			"port range with left bound set to 65536",
+			"port range with right bound set to 65536",
 			args{
 				"port",
 				"1:65536",
@@ -85,7 +93,7 @@ func TestValidatePortString(t *testing.T) {
 			true,
 		},
 		{
-			"port range with left bound that is not a int",
+			"port range with right bound that is not a int",
 			args{
 				"port",
 				"1:two",
@@ -231,7 +239,8 @@ func TestValidateServicePorts(t *testing.T) {
 				[]string{"tcp/90:8000", "udp/90:8000"},
 			},
 			false,
-		}, {
+		},
+		{
 			"serviceports with protocol numbers",
 			args{
 				[]string{"udp/90:8000", "6/90:8000"},
@@ -390,6 +399,20 @@ func TestValidateServicePorts(t *testing.T) {
 			"icmp/2/3,5,20,40 is valid",
 			args{
 				[]string{"icmp/2/3,5,20,40"},
+			},
+			false,
+		},
+		{
+			"serviceports with valid 0 port",
+			args{
+				[]string{"tcp/0", "udp/0"},
+			},
+			false,
+		},
+		{
+			"serviceports with valid full port range",
+			args{
+				[]string{"tcp/0:65535", "udp/0:65535"},
 			},
 			false,
 		},


### PR DESCRIPTION
#### Description
Port 0 used to be an invalid port to set for service port workflows, like external networks and network rule set policies. We are now going to allow port 0 to be set.

> Fixes: https://redlock.atlassian.net/browse/CNS-2424