### PR TITLE
Fix port validation in all places

### DIFF
--- a/portutils/portuils.go
+++ b/portutils/portuils.go
@@ -57,8 +57,8 @@ func ConvertToSinglePort(port string) (int64, error) {
 		return -1, fmt.Errorf("%s is not a valid port", port)
 	}
 
-	if p < 1 || p > 65535 {
-		return -1, fmt.Errorf("%s is not in between 1 and 65535", port)
+	if p < 0 || p > 65535 {
+		return -1, fmt.Errorf("%s is not in between 0 and 65535", port)
 	}
 
 	return p, nil

--- a/portutils/portutils_test.go
+++ b/portutils/portutils_test.go
@@ -290,13 +290,6 @@ func Test_ExtractPortsAndProtocolFromHostService(t *testing.T) {
 			true,
 		},
 		{
-			"single port lower than 1",
-			args{"0"},
-			nil,
-			"",
-			true,
-		},
-		{
 			"single port greater than 65535",
 			args{"65536"},
 			nil,

--- a/portutils/portutils_test.go
+++ b/portutils/portutils_test.go
@@ -161,10 +161,10 @@ func Test_ConvertToSinglePort(t *testing.T) {
 			true,
 		},
 		{
-			"single port lower than 1",
+			"single port at 0",
 			args{"0"},
-			-1,
-			true,
+			0,
+			false,
 		},
 		{
 			"single port greater than 65535",


### PR DESCRIPTION
This fixes the port validation to allow TCP ports of 0 in all validation checks (portutils used by services and NEP) 