### PR TITLE
Fix CIDR validation for excluded networks

### DIFF
--- a/cloudnetworkquery.go
+++ b/cloudnetworkquery.go
@@ -702,7 +702,7 @@ func (o *CloudNetworkQuery) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := ValidateOptionalCIDRorIPList("excludedNetworks", o.ExcludedNetworks); err != nil {
+	if err := ValidateOptionalCIDRList("excludedNetworks", o.ExcludedNetworks); err != nil {
 		errors = errors.Append(err)
 	}
 

--- a/specs/cloudnetworkquery.spec
+++ b/specs/cloudnetworkquery.spec
@@ -80,7 +80,7 @@ attributes:
     subtype: string
     stored: true
     validations:
-    - $optionalcidroriplist
+    - $optionalcidrs
 
   - name: protocolPorts
     description: |-


### PR DESCRIPTION
Excluded networks must be CIDRs.