### PR TITLE
Add validations that only east/west graphs when VPC is provided

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -1542,6 +1542,15 @@ func ValidateCloudNetworkQueryEntity(q *CloudNetworkQuery) error {
 		}
 	}
 
+	if q.SourceIP == "" && q.DestinationIP == "" {
+		if q.SourceSelector != nil && len(q.SourceSelector.VPCIDs) != 1 {
+			return makeValidationError("Entity CloudNetworkQuery", "a single source VPC must be provided for all East/West queries")
+		}
+		if q.DestinationSelector != nil && len(q.DestinationSelector.VPCIDs) != 1 {
+			return makeValidationError("Entity CloudNetworkQuery", "a single destination VPC must be provided for all East/West queries")
+		}
+	}
+
 	return nil
 }
 

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -4514,6 +4514,81 @@ func TestValidateCloudGraphQuery(t *testing.T) {
 			true,
 		},
 		{
+			"east/west with no source VPC",
+			args{
+				"invalid",
+				&CloudNetworkQuery{
+					SourceSelector: &CloudNetworkQueryFilter{
+						AccountIDs: []string{"account1"},
+					},
+					DestinationSelector: &CloudNetworkQueryFilter{
+						VPCIDs: []string{"vpc1"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"east/west with no destination VPC",
+			args{
+				"invalid",
+				&CloudNetworkQuery{
+					SourceSelector: &CloudNetworkQueryFilter{
+						VPCIDs: []string{"vpc1"},
+					},
+					DestinationSelector: &CloudNetworkQueryFilter{
+						AccountIDs: []string{"account1"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"east/west with multiple source VPCs",
+			args{
+				"invalid",
+				&CloudNetworkQuery{
+					SourceSelector: &CloudNetworkQueryFilter{
+						VPCIDs: []string{"vpc1", "vpc2"},
+					},
+					DestinationSelector: &CloudNetworkQueryFilter{
+						VPCIDs: []string{"vpc1"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"east/west with multiple destination VPCs",
+			args{
+				"invalid",
+				&CloudNetworkQuery{
+					SourceSelector: &CloudNetworkQueryFilter{
+						VPCIDs: []string{"vpc1"},
+					},
+					DestinationSelector: &CloudNetworkQueryFilter{
+						VPCIDs: []string{"vpc1", "vpc2"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"east/west valid",
+			args{
+				"invalid",
+				&CloudNetworkQuery{
+					SourceSelector: &CloudNetworkQueryFilter{
+						VPCIDs: []string{"vpc1"},
+					},
+					DestinationSelector: &CloudNetworkQueryFilter{
+						VPCIDs: []string{"vpc2"},
+					},
+				},
+			},
+			false,
+		},
+		{
 			"source ip and selector set",
 			args{
 				"invalid",


### PR DESCRIPTION
Add validations that mandates that a VPC must be provided for all the east/west graph calculations.