### PR TITLE
new/services: allow to set TLSCertificate without TLSCertificateKey

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -314,10 +314,6 @@ func ValidateServiceEntity(service *Service) error {
 		if service.TLSCertificate == "" {
 			errs = errs.Append(makeValidationError("TLSCertificate", "`TLSCertificate` is required when `TLSType` is set to `External`"))
 		}
-
-		if service.TLSCertificateKey == "" {
-			errs = errs.Append(makeValidationError("TLSCertificateKey", "`TLSCertificateKey` is required when `TLSType` is set to `External`"))
-		}
 	}
 
 	// Hosts and IPs

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -1748,20 +1748,6 @@ func TestValidateServiceEntity(t *testing.T) {
 			},
 			true,
 		},
-		{
-			"service with type TLSType set to External with missing key",
-			args{
-				&Service{
-					Hosts:             []string{"myservice.com"},
-					AuthorizationType: ServiceAuthorizationTypeMTLS,
-					TLSType:           ServiceTLSTypeExternal,
-					TLSCertificate:    "---key---",
-					Port:              80,
-					ExposedPort:       80,
-				},
-			},
-			true,
-		},
 
 		// Hosts an IP
 		{


### PR DESCRIPTION
This will allows runtime linking to ServiceCertificates