### PR TITLE
Bugfix: prevent duplicate expressions in NetRuleSetPolicy's subject

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -961,7 +961,7 @@ func ValidateTagsWithoutReservedPrefixes(attribute string, tags []string) error 
 // ValidateExpressionNotEmpty validates that expression length is >= 1
 func ValidateExpressionNotEmpty(attribute string, expression [][]string) error {
 	if len(expression) == 0 {
-		return makeValidationError(attribute, "expression must contain at least one sub-expression")
+		return makeValidationError(attribute, "Expression must contain at least one sub-expression")
 	}
 	return nil
 }
@@ -970,7 +970,7 @@ func ValidateExpressionNotEmpty(attribute string, expression [][]string) error {
 func ValidateSubExpressionsNotEmpty(attribute string, expression [][]string) error {
 	for _, subExpr := range expression {
 		if len(subExpr) == 0 {
-			return makeValidationError(attribute, "sub-expression must not be empty")
+			return makeValidationError(attribute, "Sub-expression must not be empty")
 		}
 	}
 	return nil
@@ -992,7 +992,7 @@ func ValidateEachSubExpressionHasNoDuplicateTags(attribute string, expression []
 
 			err := makeValidationError(
 				attribute,
-				fmt.Sprintf("duplicate tag in a sub-expression: '%s'", tag),
+				fmt.Sprintf("Duplicate tag in a sub-expression: '%s'", tag),
 			)
 			return err
 		}
@@ -1020,7 +1020,7 @@ func ValidateNoDuplicateSubExpressions(attribute string, expression [][]string) 
 			continue
 		}
 
-		return makeValidationError(attribute, "duplicate equivalent sub-expressions found")
+		return makeValidationError(attribute, "Duplicate equivalent sub-expressions found")
 	}
 
 	return nil
@@ -1073,7 +1073,7 @@ func ValidateNoDuplicateNetworkRules(attribute string, rules []*NetworkRule) err
 		if prevRule, ok := seen[digest]; ok {
 			return makeValidationError(
 				attribute,
-				fmt.Sprintf("duplicate network rules at the following indexes: [%d, %d]", prevRule.index+1, iRule+1),
+				fmt.Sprintf("Duplicate network rules at the following indexes: [%d, %d]", prevRule.index+1, iRule+1),
 			)
 		}
 

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -89,7 +89,7 @@ func TestValidateNoDuplicateNetworkRules(t *testing.T) {
 				},
 			},
 			attribute:   t.Name(),
-			expectedErr: makeValidationError(t.Name(), "duplicate network rules at the following indexes: [1, 2]"),
+			expectedErr: makeValidationError(t.Name(), "Duplicate network rules at the following indexes: [1, 2]"),
 		},
 		"invalid-duplicates-port-case-insensitive": {
 			rules: []*NetworkRule{
@@ -107,7 +107,7 @@ func TestValidateNoDuplicateNetworkRules(t *testing.T) {
 				},
 			},
 			attribute:   t.Name(),
-			expectedErr: makeValidationError(t.Name(), "duplicate network rules at the following indexes: [1, 2]"),
+			expectedErr: makeValidationError(t.Name(), "Duplicate network rules at the following indexes: [1, 2]"),
 		},
 		"invalid-duplicates-object-different-order": {
 			rules: []*NetworkRule{
@@ -125,7 +125,7 @@ func TestValidateNoDuplicateNetworkRules(t *testing.T) {
 				},
 			},
 			attribute:   t.Name(),
-			expectedErr: makeValidationError(t.Name(), "duplicate network rules at the following indexes: [1, 2]"),
+			expectedErr: makeValidationError(t.Name(), "Duplicate network rules at the following indexes: [1, 2]"),
 		},
 		"invalid-duplicates-object-different-order-2": {
 			rules: []*NetworkRule{
@@ -143,7 +143,7 @@ func TestValidateNoDuplicateNetworkRules(t *testing.T) {
 				},
 			},
 			attribute:   t.Name(),
-			expectedErr: makeValidationError(t.Name(), "duplicate network rules at the following indexes: [1, 2]"),
+			expectedErr: makeValidationError(t.Name(), "Duplicate network rules at the following indexes: [1, 2]"),
 		},
 		"invalid-duplicates-port-different-order": {
 			rules: []*NetworkRule{
@@ -161,7 +161,7 @@ func TestValidateNoDuplicateNetworkRules(t *testing.T) {
 				},
 			},
 			attribute:   t.Name(),
-			expectedErr: makeValidationError(t.Name(), "duplicate network rules at the following indexes: [1, 2]"),
+			expectedErr: makeValidationError(t.Name(), "Duplicate network rules at the following indexes: [1, 2]"),
 		},
 	}
 
@@ -4141,12 +4141,12 @@ func TestValidateExpressionNotEmpty(t *testing.T) {
 		"invalid-nil-expression": {
 			attribute:   t.Name(),
 			expression:  nil,
-			expectedErr: makeValidationError(t.Name(), "expression must contain at least one sub-expression"),
+			expectedErr: makeValidationError(t.Name(), "Expression must contain at least one sub-expression"),
 		},
 		"invalid-empty-expression": {
 			attribute:   t.Name(),
 			expression:  [][]string{},
-			expectedErr: makeValidationError(t.Name(), "expression must contain at least one sub-expression"),
+			expectedErr: makeValidationError(t.Name(), "Expression must contain at least one sub-expression"),
 		},
 	}
 
@@ -4194,7 +4194,7 @@ func TestValidateSubExpressionsNotEmpty(t *testing.T) {
 		"invalid-empty-expression": {
 			attribute:   t.Name(),
 			expression:  [][]string{{"a=b"}, {}},
-			expectedErr: makeValidationError(t.Name(), "sub-expression must not be empty"),
+			expectedErr: makeValidationError(t.Name(), "Sub-expression must not be empty"),
 		},
 	}
 
@@ -4242,7 +4242,7 @@ func TestValidateEachSubExpressionHasNoDuplicateTags(t *testing.T) {
 		"invalid-subexpression": {
 			attribute:   t.Name(),
 			expression:  [][]string{{"a=b"}, {"c=d", "c=d"}},
-			expectedErr: makeValidationError(t.Name(), "duplicate tag in a sub-expression: 'c=d'"),
+			expectedErr: makeValidationError(t.Name(), "Duplicate tag in a sub-expression: 'c=d'"),
 		},
 	}
 
@@ -4290,7 +4290,7 @@ func TestValidateNoDuplicateSubExpressions(t *testing.T) {
 		"invalid-expression": {
 			attribute:   t.Name(),
 			expression:  [][]string{{"a=b", "c=d"}, {"c=d"}, {"a=b"}, {"c=d", "a=b"}},
-			expectedErr: makeValidationError(t.Name(), "duplicate equivalent sub-expressions found"),
+			expectedErr: makeValidationError(t.Name(), "Duplicate equivalent sub-expressions found"),
 		},
 	}
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,35 @@
+package gaia
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"go.aporeto.io/elemental"
+)
+
+func checkValidationReturnsExpectedErr(obj elemental.Validatable, expected elemental.Error, t *testing.T) {
+	t.Helper()
+
+	err := obj.Validate()
+	if err == nil && expected == (elemental.Error{}) {
+		return
+	}
+
+	var errs elemental.Errors
+	if ok := errors.As(err, &errs); !ok {
+		t.Fatalf("unexpected error type\nwant: %T\n got: %T", errs, err)
+	}
+
+	// at this point, we should have at least one "legit" elemental error in the slice
+	actualErr := errs[0]
+
+	// we do this specific check so the error message is clear
+	if expected == (elemental.Error{}) {
+		t.Fatalf("expected no error, got: %#v", actualErr)
+	}
+
+	if !reflect.DeepEqual(actualErr, expected) {
+		t.Fatalf("unexpected error\nwant: %#v\n got: %#v", expected, actualErr)
+	}
+}

--- a/networkrulesetpolicy.go
+++ b/networkrulesetpolicy.go
@@ -682,6 +682,9 @@ func (o *NetworkRuleSetPolicy) Validate() error {
 	if err := ValidateExpressionNotEmpty("subject", o.Subject); err != nil {
 		errors = errors.Append(err)
 	}
+	if err := ValidateNoDuplicateSubExpressions("subject", o.Subject); err != nil {
+		errors = errors.Append(err)
+	}
 	if err := ValidateSubExpressionsNotEmpty("subject", o.Subject); err != nil {
 		errors = errors.Append(err)
 	}

--- a/networkrulesetpolicy_test.go
+++ b/networkrulesetpolicy_test.go
@@ -17,7 +17,32 @@ func TestNetworkRuleSetPolicy_Validate_custom(t *testing.T) {
 			p: &NetworkRuleSetPolicy{
 				Name: "dummy",
 				Subject: [][]string{
-					{"tag=valid"},
+					{"tagA=a", "tagB=b"},
+					{"tagC=c", "tagD=d"},
+				},
+				OutgoingRules: []*NetworkRule{
+					{
+						Action:        NetworkRuleActionAllow,
+						Object:        [][]string{{"tag1=a", "tag2=b"}},
+						ProtocolPorts: []string{"udp/123", "tcp/80"},
+					},
+					{
+						Action:        NetworkRuleActionAllow,
+						Object:        [][]string{{"tag3=c", "tag4=d"}},
+						ProtocolPorts: []string{"tcp/90", "udp/456"},
+					},
+				},
+				IncomingRules: []*NetworkRule{
+					{
+						Action:        NetworkRuleActionAllow,
+						Object:        [][]string{{"tag5=e", "tag6=f"}},
+						ProtocolPorts: []string{"udp/789", "tcp/100"},
+					},
+					{
+						Action:        NetworkRuleActionAllow,
+						Object:        [][]string{{"tag7=g", "tag8=h"}},
+						ProtocolPorts: []string{"tcp/110", "udp/101"},
+					},
 				},
 			},
 		},

--- a/networkrulesetpolicy_test.go
+++ b/networkrulesetpolicy_test.go
@@ -1,0 +1,120 @@
+package gaia
+
+import (
+	"testing"
+
+	"go.aporeto.io/elemental"
+)
+
+func TestNetworkRuleSetPolicy_Validate_custom(t *testing.T) {
+
+	cases := map[string]struct {
+		p   *NetworkRuleSetPolicy
+		err elemental.Error
+	}{
+
+		"valid": {
+			p: &NetworkRuleSetPolicy{
+				Name: "dummy",
+				Subject: [][]string{
+					{"tag=valid"},
+				},
+			},
+		},
+
+		"empty-subject": {
+			p: &NetworkRuleSetPolicy{
+				Name:    "dummy",
+				Subject: nil,
+			},
+			err: makeValidationError("subject", "Expression must contain at least one sub-expression"),
+		},
+
+		"empty-subexpression-in-subject": {
+			p: &NetworkRuleSetPolicy{
+				Name:    "dummy",
+				Subject: [][]string{{}},
+			},
+			err: makeValidationError("subject", "Sub-expression must not be empty"),
+		},
+
+		"duplicate-tags-in-subject": {
+			p: &NetworkRuleSetPolicy{
+				Name: "dummy",
+				Subject: [][]string{
+					{"tag=dup", "tag=dup"},
+				},
+			},
+			err: makeValidationError("subject", "Duplicate tag in a sub-expression: 'tag=dup'"),
+		},
+
+		"duplicate-subexpressions-in-subject": {
+			p: &NetworkRuleSetPolicy{
+				Name: "dummy",
+				Subject: [][]string{
+					{"tag1=a", "tag2=b"},
+					{"tag2=b", "tag1=a"},
+				},
+			},
+			err: makeValidationError("subject", "Duplicate equivalent sub-expressions found"),
+		},
+
+		"bad-tag-in-subject": {
+			p: &NetworkRuleSetPolicy{
+				Name:    "dummy",
+				Subject: [][]string{{"troubles"}},
+			},
+			err: makeValidationError("subject", "'troubles' must contain at least one '=' symbol separating two valid words"),
+		},
+
+		"duplicate-incoming-rules": {
+			p: &NetworkRuleSetPolicy{
+				Name: "dummy",
+				Subject: [][]string{
+					{"tag=valid"},
+				},
+				IncomingRules: []*NetworkRule{
+					{
+						Action:        NetworkRuleActionAllow,
+						Object:        [][]string{{"tag1=a", "tag2=b"}},
+						ProtocolPorts: []string{"udp/123", "tcp/80"},
+					},
+					{
+						Action:        NetworkRuleActionAllow,
+						Object:        [][]string{{"tag2=b", "tag1=a"}},
+						ProtocolPorts: []string{"tcp/80", "udp/123"},
+					},
+				},
+			},
+			err: makeValidationError("incomingRules", "Duplicate network rules at the following indexes: [1, 2]"),
+		},
+
+		"duplicate-outgoing-rules": {
+			p: &NetworkRuleSetPolicy{
+				Name: "dummy",
+				Subject: [][]string{
+					{"tag=valid"},
+				},
+				OutgoingRules: []*NetworkRule{
+					{
+						Action:        NetworkRuleActionAllow,
+						Object:        [][]string{{"tag1=a", "tag2=b"}},
+						ProtocolPorts: []string{"udp/123", "tcp/80"},
+					},
+					{
+						Action:        NetworkRuleActionAllow,
+						Object:        [][]string{{"tag2=b", "tag1=a"}},
+						ProtocolPorts: []string{"tcp/80", "udp/123"},
+					},
+				},
+			},
+			err: makeValidationError("outgoingRules", "Duplicate network rules at the following indexes: [1, 2]"),
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			checkValidationReturnsExpectedErr(c.p, c.err, t)
+		})
+	}
+}

--- a/specs/networkrulesetpolicy.spec
+++ b/specs/networkrulesetpolicy.spec
@@ -80,6 +80,7 @@ attributes:
     - $atLeastOneSubExpression
     - $subExpressionsNotEmpty
     - $noDuplicateTagsInEachSubExpression
+    - $noDuplicateSubExpressions
     - $tagsExpression
 
 # Relations


### PR DESCRIPTION
This PR also make the first letter of error messages uppercase for consistency.

Reference JIRA tickets: [CNS-2829](https://redlock.atlassian.net/browse/CNS-2829?atlOrigin=eyJpIjoiNGQ1ZWNjYjU2MjFiNGM3ODllZjBmOTI5Mzg0OGMzOTgiLCJwIjoiaiJ9) and [CNS-2830](https://redlock.atlassian.net/browse/CNS-2830?atlOrigin=eyJpIjoiYjI5MGMwNGM1MmNkNDFkMmIwMDg2ZGQ1MGU3NzM3NTkiLCJwIjoiaiJ9)