### PR TITLE
fixed/apicheck: validate input namespace

### DIFF
--- a/apicheck.go
+++ b/apicheck.go
@@ -298,6 +298,10 @@ func (o *APICheck) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
+	if err := elemental.ValidatePattern("namespace", o.Namespace, `^/[a-zA-Z0-9-_/]*$`, `must only contain alpha numerical characters, '-' or '_' and start with '/'`, true); err != nil {
+		errors = errors.Append(err)
+	}
+
 	if err := elemental.ValidateRequiredString("operation", string(o.Operation)); err != nil {
 		requiredErrors = requiredErrors.Append(err)
 	}
@@ -371,6 +375,7 @@ var APICheckAttributesMap = map[string]elemental.AttributeSpecification{
 		Type:           "external",
 	},
 	"Namespace": {
+		AllowedChars:   `^/[a-zA-Z0-9-_/]*$`,
 		AllowedChoices: []string{},
 		ConvertedName:  "Namespace",
 		Description:    `The namespace to use to check the API authorization.`,
@@ -419,6 +424,7 @@ var APICheckLowerCaseAttributesMap = map[string]elemental.AttributeSpecification
 		Type:           "external",
 	},
 	"namespace": {
+		AllowedChars:   `^/[a-zA-Z0-9-_/]*$`,
 		AllowedChoices: []string{},
 		ConvertedName:  "Namespace",
 		Description:    `The namespace to use to check the API authorization.`,

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -13056,7 +13056,7 @@ Type: `map[string]bool`
 
 Contains the results of the check.
 
-##### `namespace` [`required`]
+##### `namespace` [`required`,`format=^/[a-zA-Z0-9-_/]*$`]
 
 Type: `string`
 

--- a/specs/apicheck.spec
+++ b/specs/apicheck.spec
@@ -26,6 +26,8 @@ attributes:
     exposed: true
     required: true
     example_value: /namespace
+    allowed_chars: ^/[a-zA-Z0-9-_/]*$
+    allowed_chars_message: must only contain alpha numerical characters, '-' or '_' and start with '/'
 
   - name: operation
     description: The operation you want to check.


### PR DESCRIPTION
Validate `namespace` property to get a 422 instead of a 500 in case of bad input