### PR TITLE
New: Add includePropagatedExtNets filter option on tag retrievemany

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -7241,6 +7241,7 @@ Retrieves the list of existing tags in the system.
 
 Parameters:
 
+- `includePropagatedExtNets` (`boolean`): if set to true, include propagated external network name tags.
 - `onlyPolicyTags` (`boolean`): if set to true, only return tags that match the tag prefixes.
 - `q` (`string`): Filtering query. Consequent `q` parameters will form an or.
 

--- a/relationships_registry.go
+++ b/relationships_registry.go
@@ -5329,6 +5329,10 @@ func init() {
 			"root": {
 				Parameters: []elemental.ParameterDefinition{
 					{
+						Name: "includePropagatedExtNets",
+						Type: "boolean",
+					},
+					{
 						Name: "onlyPolicyTags",
 						Type: "boolean",
 					},
@@ -5343,6 +5347,10 @@ func init() {
 		Info: map[string]*elemental.RelationshipInfo{
 			"root": {
 				Parameters: []elemental.ParameterDefinition{
+					{
+						Name: "includePropagatedExtNets",
+						Type: "boolean",
+					},
 					{
 						Name: "onlyPolicyTags",
 						Type: "boolean",

--- a/specs/root.spec
+++ b/specs/root.spec
@@ -1111,6 +1111,10 @@ relations:
     - $filtering
     parameters:
       entries:
+      - name: includePropagatedExtNets
+        description: if set to true, include propagated external network name tags.
+        type: boolean
+
       - name: onlyPolicyTags
         description: if set to true, only return tags that match the tag prefixes.
         type: boolean


### PR DESCRIPTION
#### Description
if `includePropagatedExtNets` is set to true, we will now also include propagated external network name tags during tag retrievemany.