### PR TITLE
New: Add force parameter for tagprefix API

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -5316,6 +5316,10 @@ Returns the tag prefixes of the specified namespace.
 
 Modify the tag prefixes of the specified namespace.
 
+Parameters:
+
+- `force` (`boolean`): if set to true, it will update a namespace's tag prefixes even if the namespace is protected.
+
 #### Attributes
 
 ##### `prefixes`

--- a/relationships_registry.go
+++ b/relationships_registry.go
@@ -5413,7 +5413,14 @@ func init() {
 
 	relationshipsRegistry[TagPrefixIdentity] = &elemental.Relationship{
 		Create: map[string]*elemental.RelationshipInfo{
-			"root": {},
+			"root": {
+				Parameters: []elemental.ParameterDefinition{
+					{
+						Name: "force",
+						Type: "boolean",
+					},
+				},
+			},
 		},
 		RetrieveMany: map[string]*elemental.RelationshipInfo{
 			"root": {},

--- a/specs/root.spec
+++ b/specs/root.spec
@@ -1125,6 +1125,11 @@ relations:
     description: Returns the tag prefixes of the specified namespace.
   create:
     description: Modify the tag prefixes of the specified namespace.
+    parameters:
+      entries:
+      - name: force
+        description: if set to true, it will update a namespace's tag prefixes even if the namespace is protected.
+        type: boolean
 
 - rest_name: tagvalue
   get:


### PR DESCRIPTION
#### Description
Some namespaces are created with the protected state set to true. There are situations where a System Admin would want to update a namespace's tag prefixes and currently we do not allow proxy APIs to edit protected namespaces. To allow this use-case, we are introducing the parameter `force` on tagprefix API which, when set to true, will bypass protected state to update the tag prefixes.

> Fixes: https://redlock.atlassian.net/browse/CNS-3251