### PR TITLE
WIP: cid: custom validation for api auth policy format

### DIFF
--- a/apiauthorizationpolicy.go
+++ b/apiauthorizationpolicy.go
@@ -817,6 +817,10 @@ func (o *APIAuthorizationPolicy) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
+	if err := ValidateFormatForAuthorizedIdentities("authorizedIdentities", o.AuthorizedIdentities); err != nil {
+		errors = errors.Append(err)
+	}
+
 	if err := elemental.ValidateRequiredString("authorizedNamespace", o.AuthorizedNamespace); err != nil {
 		requiredErrors = requiredErrors.Append(err)
 	}

--- a/specs/_validation.mapping
+++ b/specs/_validation.mapping
@@ -238,6 +238,10 @@ $uiparameters:
   elemental:
     name: ValidateUIParameters
 
+$validateFormatForAuthorizedIdentities:
+  elemental:
+    name: ValidateFormatForAuthorizedIdentities
+
 $writeoperations:
   elemental:
     name: ValidateWriteOperations

--- a/specs/apiauthorizationpolicy.spec
+++ b/specs/apiauthorizationpolicy.spec
@@ -69,6 +69,8 @@ attributes:
     required: true
     example_value:
     - '@auth:role=namespace.administrator'
+    validations:
+    - $validateFormatForAuthorizedIdentities
 
   - name: authorizedNamespace
     description: Defines the namespace the user is authorized to access.
@@ -90,8 +92,7 @@ attributes:
     - $optionalcidrs
 
   - name: expirationTime
-    description: If set, the policy will be automatically deleted after the given
-      time.
+    description: If set, the policy will be automatically deleted after the given time.
     type: time
     exposed: true
     stored: true


### PR DESCRIPTION
This PR is needed to prevent creating APIAuthorizationPolicy with bad `AuthorizedIdentities` field like this:
```
apoctl api create apiauthorizationpolicy \
--data '{
  "authorizedIdentities": ["enforcer,idk,asd", "this,is,bad"],
}'
```