### PR TITLE
ReportsQuery: add support for reading out AccessReports

### DIFF
--- a/accessreport.go
+++ b/accessreport.go
@@ -129,6 +129,10 @@ type AccessReport struct {
 	// Internal property maintaining migrations information.
 	MigrationsLog map[string]string `json:"-" msgpack:"-" bson:"migrationslog,omitempty" mapstructure:"-,omitempty"`
 
+	// The namespace that this access report belongs to. This field is not exposed.
+	// Therefore, any value set by the user will be ignored.
+	Namespace string `json:"-" msgpack:"-" bson:"k,omitempty" mapstructure:"-,omitempty"`
+
 	// ID of the processing unit of the report.
 	ProcessingUnitID string `json:"processingUnitID,omitempty" msgpack:"processingUnitID,omitempty" bson:"e,omitempty" mapstructure:"processingUnitID,omitempty"`
 
@@ -203,6 +207,7 @@ func (o *AccessReport) GetBSON() (interface{}, error) {
 	s.EnforcerID = o.EnforcerID
 	s.EnforcerNamespace = o.EnforcerNamespace
 	s.MigrationsLog = o.MigrationsLog
+	s.Namespace = o.Namespace
 	s.ProcessingUnitID = o.ProcessingUnitID
 	s.ProcessingUnitName = o.ProcessingUnitName
 	s.ProcessingUnitNamespace = o.ProcessingUnitNamespace
@@ -234,6 +239,7 @@ func (o *AccessReport) SetBSON(raw bson.Raw) error {
 	o.EnforcerID = s.EnforcerID
 	o.EnforcerNamespace = s.EnforcerNamespace
 	o.MigrationsLog = s.MigrationsLog
+	o.Namespace = s.Namespace
 	o.ProcessingUnitID = s.ProcessingUnitID
 	o.ProcessingUnitName = s.ProcessingUnitName
 	o.ProcessingUnitNamespace = s.ProcessingUnitNamespace
@@ -326,6 +332,7 @@ func (o *AccessReport) ToSparse(fields ...string) elemental.SparseIdentifiable {
 			EnforcerID:              &o.EnforcerID,
 			EnforcerNamespace:       &o.EnforcerNamespace,
 			MigrationsLog:           &o.MigrationsLog,
+			Namespace:               &o.Namespace,
 			ProcessingUnitID:        &o.ProcessingUnitID,
 			ProcessingUnitName:      &o.ProcessingUnitName,
 			ProcessingUnitNamespace: &o.ProcessingUnitNamespace,
@@ -352,6 +359,8 @@ func (o *AccessReport) ToSparse(fields ...string) elemental.SparseIdentifiable {
 			sp.EnforcerNamespace = &(o.EnforcerNamespace)
 		case "migrationsLog":
 			sp.MigrationsLog = &(o.MigrationsLog)
+		case "namespace":
+			sp.Namespace = &(o.Namespace)
 		case "processingUnitID":
 			sp.ProcessingUnitID = &(o.ProcessingUnitID)
 		case "processingUnitName":
@@ -398,6 +407,9 @@ func (o *AccessReport) Patch(sparse elemental.SparseIdentifiable) {
 	}
 	if so.MigrationsLog != nil {
 		o.MigrationsLog = *so.MigrationsLog
+	}
+	if so.Namespace != nil {
+		o.Namespace = *so.Namespace
 	}
 	if so.ProcessingUnitID != nil {
 		o.ProcessingUnitID = *so.ProcessingUnitID
@@ -525,6 +537,8 @@ func (o *AccessReport) ValueForAttribute(name string) interface{} {
 		return o.EnforcerNamespace
 	case "migrationsLog":
 		return o.MigrationsLog
+	case "namespace":
+		return o.Namespace
 	case "processingUnitID":
 		return o.ProcessingUnitID
 	case "processingUnitName":
@@ -617,6 +631,17 @@ var AccessReportAttributesMap = map[string]elemental.AttributeSpecification{
 		Stored:         true,
 		SubType:        "map[string]string",
 		Type:           "external",
+	},
+	"Namespace": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "k",
+		ConvertedName:  "Namespace",
+		Description: `The namespace that this access report belongs to. This field is not exposed.
+Therefore, any value set by the user will be ignored.`,
+		Filterable: true,
+		Name:       "namespace",
+		Stored:     true,
+		Type:       "string",
 	},
 	"ProcessingUnitID": {
 		AllowedChoices: []string{},
@@ -782,6 +807,17 @@ var AccessReportLowerCaseAttributesMap = map[string]elemental.AttributeSpecifica
 		Stored:         true,
 		SubType:        "map[string]string",
 		Type:           "external",
+	},
+	"namespace": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "k",
+		ConvertedName:  "Namespace",
+		Description: `The namespace that this access report belongs to. This field is not exposed.
+Therefore, any value set by the user will be ignored.`,
+		Filterable: true,
+		Name:       "namespace",
+		Stored:     true,
+		Type:       "string",
 	},
 	"processingunitid": {
 		AllowedChoices: []string{},
@@ -959,6 +995,10 @@ type SparseAccessReport struct {
 	// Internal property maintaining migrations information.
 	MigrationsLog *map[string]string `json:"-" msgpack:"-" bson:"migrationslog,omitempty" mapstructure:"-,omitempty"`
 
+	// The namespace that this access report belongs to. This field is not exposed.
+	// Therefore, any value set by the user will be ignored.
+	Namespace *string `json:"-" msgpack:"-" bson:"k,omitempty" mapstructure:"-,omitempty"`
+
 	// ID of the processing unit of the report.
 	ProcessingUnitID *string `json:"processingUnitID,omitempty" msgpack:"processingUnitID,omitempty" bson:"e,omitempty" mapstructure:"processingUnitID,omitempty"`
 
@@ -1046,6 +1086,9 @@ func (o *SparseAccessReport) GetBSON() (interface{}, error) {
 	if o.MigrationsLog != nil {
 		s.MigrationsLog = o.MigrationsLog
 	}
+	if o.Namespace != nil {
+		s.Namespace = o.Namespace
+	}
 	if o.ProcessingUnitID != nil {
 		s.ProcessingUnitID = o.ProcessingUnitID
 	}
@@ -1104,6 +1147,9 @@ func (o *SparseAccessReport) SetBSON(raw bson.Raw) error {
 	if s.MigrationsLog != nil {
 		o.MigrationsLog = s.MigrationsLog
 	}
+	if s.Namespace != nil {
+		o.Namespace = s.Namespace
+	}
 	if s.ProcessingUnitID != nil {
 		o.ProcessingUnitID = s.ProcessingUnitID
 	}
@@ -1159,6 +1205,9 @@ func (o *SparseAccessReport) ToPlain() elemental.PlainIdentifiable {
 	}
 	if o.MigrationsLog != nil {
 		out.MigrationsLog = *o.MigrationsLog
+	}
+	if o.Namespace != nil {
+		out.Namespace = *o.Namespace
 	}
 	if o.ProcessingUnitID != nil {
 		out.ProcessingUnitID = *o.ProcessingUnitID
@@ -1267,6 +1316,7 @@ type mongoAttributesAccessReport struct {
 	EnforcerID              string                  `bson:"c,omitempty"`
 	EnforcerNamespace       string                  `bson:"d,omitempty"`
 	MigrationsLog           map[string]string       `bson:"migrationslog,omitempty"`
+	Namespace               string                  `bson:"k,omitempty"`
 	ProcessingUnitID        string                  `bson:"e,omitempty"`
 	ProcessingUnitName      string                  `bson:"f,omitempty"`
 	ProcessingUnitNamespace string                  `bson:"g,omitempty"`
@@ -1283,6 +1333,7 @@ type mongoAttributesSparseAccessReport struct {
 	EnforcerID              *string                  `bson:"c,omitempty"`
 	EnforcerNamespace       *string                  `bson:"d,omitempty"`
 	MigrationsLog           *map[string]string       `bson:"migrationslog,omitempty"`
+	Namespace               *string                  `bson:"k,omitempty"`
 	ProcessingUnitID        *string                  `bson:"e,omitempty"`
 	ProcessingUnitName      *string                  `bson:"f,omitempty"`
 	ProcessingUnitNamespace *string                  `bson:"g,omitempty"`

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -21065,6 +21065,12 @@ Type: [`[]dnslookupreport`](#dnslookupreport)
 
 List of DNSLookupReports.
 
+##### `accessReports`
+
+Type: [`[]accessreport`](#accessreport)
+
+List of AccessReports.
+
 ##### `connectionExceptionReports`
 
 Type: [`[]connectionexceptionreport`](#connectionexceptionreport)
@@ -21103,7 +21109,7 @@ List of PacketReports.
 
 ##### `report`
 
-Type: `enum(Flows | Enforcers | EventLogs | Packets | Counters | DNSLookups | ConnectionExceptions)`
+Type: `enum(Accesses | Flows | Enforcers | EventLogs | Packets | Counters | DNSLookups | ConnectionExceptions)`
 
 Name of the report type to query.
 

--- a/reportsquery.go
+++ b/reportsquery.go
@@ -12,6 +12,9 @@ import (
 type ReportsQueryReportValue string
 
 const (
+	// ReportsQueryReportAccesses represents the value Accesses.
+	ReportsQueryReportAccesses ReportsQueryReportValue = "Accesses"
+
 	// ReportsQueryReportConnectionExceptions represents the value ConnectionExceptions.
 	ReportsQueryReportConnectionExceptions ReportsQueryReportValue = "ConnectionExceptions"
 
@@ -109,6 +112,9 @@ type ReportsQuery struct {
 	// List of DNSLookupReports.
 	DNSLookupReports DNSLookupReportsList `json:"DNSLookupReports,omitempty" msgpack:"DNSLookupReports,omitempty" bson:"-" mapstructure:"DNSLookupReports,omitempty"`
 
+	// List of AccessReports.
+	AccessReports AccessReportsList `json:"accessReports,omitempty" msgpack:"accessReports,omitempty" bson:"-" mapstructure:"accessReports,omitempty"`
+
 	// List of ConnectionExceptionReports.
 	ConnectionExceptionReports ConnectionExceptionReportsList `json:"connectionExceptionReports,omitempty" msgpack:"connectionExceptionReports,omitempty" bson:"-" mapstructure:"connectionExceptionReports,omitempty"`
 
@@ -138,8 +144,9 @@ func NewReportsQuery() *ReportsQuery {
 
 	return &ReportsQuery{
 		ModelVersion:               1,
-		ConnectionExceptionReports: ConnectionExceptionReportsList{},
+		AccessReports:              AccessReportsList{},
 		DNSLookupReports:           DNSLookupReportsList{},
+		ConnectionExceptionReports: ConnectionExceptionReportsList{},
 		CounterReports:             CounterReportsList{},
 		EnforcerReports:            EnforcerReportsList{},
 		EventLogs:                  EventLogsList{},
@@ -233,6 +240,7 @@ func (o *ReportsQuery) ToSparse(fields ...string) elemental.SparseIdentifiable {
 		// nolint: goimports
 		return &SparseReportsQuery{
 			DNSLookupReports:           &o.DNSLookupReports,
+			AccessReports:              &o.AccessReports,
 			ConnectionExceptionReports: &o.ConnectionExceptionReports,
 			CounterReports:             &o.CounterReports,
 			EnforcerReports:            &o.EnforcerReports,
@@ -248,6 +256,8 @@ func (o *ReportsQuery) ToSparse(fields ...string) elemental.SparseIdentifiable {
 		switch f {
 		case "DNSLookupReports":
 			sp.DNSLookupReports = &(o.DNSLookupReports)
+		case "accessReports":
+			sp.AccessReports = &(o.AccessReports)
 		case "connectionExceptionReports":
 			sp.ConnectionExceptionReports = &(o.ConnectionExceptionReports)
 		case "counterReports":
@@ -277,6 +287,9 @@ func (o *ReportsQuery) Patch(sparse elemental.SparseIdentifiable) {
 	so := sparse.(*SparseReportsQuery)
 	if so.DNSLookupReports != nil {
 		o.DNSLookupReports = *so.DNSLookupReports
+	}
+	if so.AccessReports != nil {
+		o.AccessReports = *so.AccessReports
 	}
 	if so.ConnectionExceptionReports != nil {
 		o.ConnectionExceptionReports = *so.ConnectionExceptionReports
@@ -332,6 +345,16 @@ func (o *ReportsQuery) Validate() error {
 	requiredErrors := elemental.Errors{}
 
 	for _, sub := range o.DNSLookupReports {
+		if sub == nil {
+			continue
+		}
+		elemental.ResetDefaultForZeroValues(sub)
+		if err := sub.Validate(); err != nil {
+			errors = errors.Append(err)
+		}
+	}
+
+	for _, sub := range o.AccessReports {
 		if sub == nil {
 			continue
 		}
@@ -401,7 +424,7 @@ func (o *ReportsQuery) Validate() error {
 		}
 	}
 
-	if err := elemental.ValidateStringInList("report", string(o.Report), []string{"Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups", "ConnectionExceptions"}, false); err != nil {
+	if err := elemental.ValidateStringInList("report", string(o.Report), []string{"Accesses", "Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups", "ConnectionExceptions"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -441,6 +464,8 @@ func (o *ReportsQuery) ValueForAttribute(name string) interface{} {
 	switch name {
 	case "DNSLookupReports":
 		return o.DNSLookupReports
+	case "accessReports":
+		return o.AccessReports
 	case "connectionExceptionReports":
 		return o.ConnectionExceptionReports
 	case "counterReports":
@@ -469,6 +494,15 @@ var ReportsQueryAttributesMap = map[string]elemental.AttributeSpecification{
 		Exposed:        true,
 		Name:           "DNSLookupReports",
 		SubType:        "dnslookupreport",
+		Type:           "refList",
+	},
+	"AccessReports": {
+		AllowedChoices: []string{},
+		ConvertedName:  "AccessReports",
+		Description:    `List of AccessReports.`,
+		Exposed:        true,
+		Name:           "accessReports",
+		SubType:        "accessreport",
 		Type:           "refList",
 	},
 	"ConnectionExceptionReports": {
@@ -526,7 +560,7 @@ var ReportsQueryAttributesMap = map[string]elemental.AttributeSpecification{
 		Type:           "refList",
 	},
 	"Report": {
-		AllowedChoices: []string{"Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups", "ConnectionExceptions"},
+		AllowedChoices: []string{"Accesses", "Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups", "ConnectionExceptions"},
 		ConvertedName:  "Report",
 		DefaultValue:   ReportsQueryReportFlows,
 		Description:    `Name of the report type to query.`,
@@ -545,6 +579,15 @@ var ReportsQueryLowerCaseAttributesMap = map[string]elemental.AttributeSpecifica
 		Exposed:        true,
 		Name:           "DNSLookupReports",
 		SubType:        "dnslookupreport",
+		Type:           "refList",
+	},
+	"accessreports": {
+		AllowedChoices: []string{},
+		ConvertedName:  "AccessReports",
+		Description:    `List of AccessReports.`,
+		Exposed:        true,
+		Name:           "accessReports",
+		SubType:        "accessreport",
 		Type:           "refList",
 	},
 	"connectionexceptionreports": {
@@ -602,7 +645,7 @@ var ReportsQueryLowerCaseAttributesMap = map[string]elemental.AttributeSpecifica
 		Type:           "refList",
 	},
 	"report": {
-		AllowedChoices: []string{"Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups", "ConnectionExceptions"},
+		AllowedChoices: []string{"Accesses", "Flows", "Enforcers", "EventLogs", "Packets", "Counters", "DNSLookups", "ConnectionExceptions"},
 		ConvertedName:  "Report",
 		DefaultValue:   ReportsQueryReportFlows,
 		Description:    `Name of the report type to query.`,
@@ -677,6 +720,9 @@ func (o SparseReportsQueriesList) Version() int {
 type SparseReportsQuery struct {
 	// List of DNSLookupReports.
 	DNSLookupReports *DNSLookupReportsList `json:"DNSLookupReports,omitempty" msgpack:"DNSLookupReports,omitempty" bson:"-" mapstructure:"DNSLookupReports,omitempty"`
+
+	// List of AccessReports.
+	AccessReports *AccessReportsList `json:"accessReports,omitempty" msgpack:"accessReports,omitempty" bson:"-" mapstructure:"accessReports,omitempty"`
 
 	// List of ConnectionExceptionReports.
 	ConnectionExceptionReports *ConnectionExceptionReportsList `json:"connectionExceptionReports,omitempty" msgpack:"connectionExceptionReports,omitempty" bson:"-" mapstructure:"connectionExceptionReports,omitempty"`
@@ -765,6 +811,9 @@ func (o *SparseReportsQuery) ToPlain() elemental.PlainIdentifiable {
 	out := NewReportsQuery()
 	if o.DNSLookupReports != nil {
 		out.DNSLookupReports = *o.DNSLookupReports
+	}
+	if o.AccessReports != nil {
+		out.AccessReports = *o.AccessReports
 	}
 	if o.ConnectionExceptionReports != nil {
 		out.ConnectionExceptionReports = *o.ConnectionExceptionReports

--- a/specs/accessreport.spec
+++ b/specs/accessreport.spec
@@ -69,6 +69,18 @@ attributes:
     extensions:
       bson_name: d
 
+  - name: namespace
+    description: |-
+      The namespace that this access report belongs to. This field is not exposed.
+      Therefore, any value set by the user will be ignored.
+    type: string
+    stored: true
+    example_value: /my/namespace
+    filterable: true
+    omit_empty: true
+    extensions:
+      bson_name: k
+
   - name: processingUnitID
     description: ID of the processing unit of the report.
     type: string

--- a/specs/reportsquery.spec
+++ b/specs/reportsquery.spec
@@ -21,6 +21,13 @@ attributes:
     subtype: dnslookupreport
     omit_empty: true
 
+  - name: accessReports
+    description: List of AccessReports.
+    type: refList
+    exposed: true
+    subtype: accessreport
+    omit_empty: true
+
   - name: connectionExceptionReports
     description: List of ConnectionExceptionReports.
     type: refList
@@ -68,6 +75,7 @@ attributes:
     type: enum
     exposed: true
     allowed_choices:
+    - Accesses
     - Flows
     - Enforcers
     - EventLogs


### PR DESCRIPTION
This PR modifies the ReportQuery model in order to support reading out AccessReports via the /reportsQuery endpoint.  Note that new field `Namespace` is introduced to AccessReport because when jenova attempts to read out access reports, it makes a query to mongodb using the namespace filter... Without that field, the results will always be empty. For more information, see [this sister PR](https://git.scm.prismacloud.io/prismacloud/pcn/backend/-/merge_requests/1496)