### PR TITLE
add flowReportInterval to enforcer profile

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -14834,6 +14834,7 @@ profile mapping.
 
 ```json
 {
+  "flowReportInterval": "30m",
   "kubernetesMetadataExtractor": "PodAtomic",
   "kubernetesSupportEnabled": false,
   "metadataExtractor": "Docker",
@@ -14940,6 +14941,18 @@ Type: `[]string`
 Ignore any networks specified here and do not even report any flows.
 This can be useful for excluding localhost loopback traffic, ignoring
 traffic to the Kubernetes API, and using Microsegmentation for SSH only.
+
+##### `flowReportInterval`
+
+Type: `string`
+
+Frequency that flow report counts are upated.
+
+Default value:
+
+```json
+"30m"
+```
 
 ##### `ignoreExpression`
 

--- a/enforcerprofile.go
+++ b/enforcerprofile.go
@@ -153,6 +153,9 @@ type EnforcerProfile struct {
 	// traffic to the Kubernetes API, and using Microsegmentation for SSH only.
 	ExcludedNetworks []string `json:"excludedNetworks" msgpack:"excludedNetworks" bson:"excludednetworks" mapstructure:"excludedNetworks,omitempty"`
 
+	// Frequency that flow report counts are upated.
+	FlowReportInterval string `json:"flowReportInterval" msgpack:"flowReportInterval" bson:"flowreportinterval" mapstructure:"flowReportInterval,omitempty"`
+
 	// A tag expression that identifies processing units to ignore. This can be
 	// useful to exclude `kube-system` pods, AWS EC2 agent pods, and third-party
 	// agents.
@@ -246,12 +249,13 @@ func NewEnforcerProfile() *EnforcerProfile {
 		Annotations:                 map[string][]string{},
 		ExcludedInterfaces:          []string{},
 		AssociatedTags:              []string{},
+		FlowReportInterval:          "30m",
 		ExcludedNetworks:            []string{},
-		NormalizedTags:              []string{},
 		IgnoreExpression:            [][]string{},
 		MetadataExtractor:           EnforcerProfileMetadataExtractorDocker,
 		SyslogFacility:              1,
 		SyslogFormat:                EnforcerProfileSyslogFormatAuto,
+		NormalizedTags:              []string{},
 		TargetNetworks:              []string{},
 		TrustedCAs:                  []string{},
 		TargetUDPNetworks:           []string{},
@@ -299,6 +303,7 @@ func (o *EnforcerProfile) GetBSON() (interface{}, error) {
 	s.Description = o.Description
 	s.ExcludedInterfaces = o.ExcludedInterfaces
 	s.ExcludedNetworks = o.ExcludedNetworks
+	s.FlowReportInterval = o.FlowReportInterval
 	s.IgnoreExpression = o.IgnoreExpression
 	s.KubernetesMetadataExtractor = o.KubernetesMetadataExtractor
 	s.KubernetesSupportEnabled = o.KubernetesSupportEnabled
@@ -348,6 +353,7 @@ func (o *EnforcerProfile) SetBSON(raw bson.Raw) error {
 	o.Description = s.Description
 	o.ExcludedInterfaces = s.ExcludedInterfaces
 	o.ExcludedNetworks = s.ExcludedNetworks
+	o.FlowReportInterval = s.FlowReportInterval
 	o.IgnoreExpression = s.IgnoreExpression
 	o.KubernetesMetadataExtractor = s.KubernetesMetadataExtractor
 	o.KubernetesSupportEnabled = s.KubernetesSupportEnabled
@@ -617,6 +623,7 @@ func (o *EnforcerProfile) ToSparse(fields ...string) elemental.SparseIdentifiabl
 			Description:                        &o.Description,
 			ExcludedInterfaces:                 &o.ExcludedInterfaces,
 			ExcludedNetworks:                   &o.ExcludedNetworks,
+			FlowReportInterval:                 &o.FlowReportInterval,
 			IgnoreExpression:                   &o.IgnoreExpression,
 			KubernetesMetadataExtractor:        &o.KubernetesMetadataExtractor,
 			KubernetesSupportEnabled:           &o.KubernetesSupportEnabled,
@@ -663,6 +670,8 @@ func (o *EnforcerProfile) ToSparse(fields ...string) elemental.SparseIdentifiabl
 			sp.ExcludedInterfaces = &(o.ExcludedInterfaces)
 		case "excludedNetworks":
 			sp.ExcludedNetworks = &(o.ExcludedNetworks)
+		case "flowReportInterval":
+			sp.FlowReportInterval = &(o.FlowReportInterval)
 		case "ignoreExpression":
 			sp.IgnoreExpression = &(o.IgnoreExpression)
 		case "kubernetesMetadataExtractor":
@@ -747,6 +756,9 @@ func (o *EnforcerProfile) Patch(sparse elemental.SparseIdentifiable) {
 	}
 	if so.ExcludedNetworks != nil {
 		o.ExcludedNetworks = *so.ExcludedNetworks
+	}
+	if so.FlowReportInterval != nil {
+		o.FlowReportInterval = *so.FlowReportInterval
 	}
 	if so.IgnoreExpression != nil {
 		o.IgnoreExpression = *so.IgnoreExpression
@@ -860,6 +872,10 @@ func (o *EnforcerProfile) Validate() error {
 		errors = errors.Append(err)
 	}
 
+	if err := ValidateTimeDuration("flowReportInterval", o.FlowReportInterval); err != nil {
+		errors = errors.Append(err)
+	}
+
 	if err := ValidateTagsExpression("ignoreExpression", o.IgnoreExpression); err != nil {
 		errors = errors.Append(err)
 	}
@@ -963,6 +979,8 @@ func (o *EnforcerProfile) ValueForAttribute(name string) interface{} {
 		return o.ExcludedInterfaces
 	case "excludedNetworks":
 		return o.ExcludedNetworks
+	case "flowReportInterval":
+		return o.FlowReportInterval
 	case "ignoreExpression":
 		return o.IgnoreExpression
 	case "kubernetesMetadataExtractor":
@@ -1127,6 +1145,17 @@ traffic to the Kubernetes API, and using Microsegmentation for SSH only.`,
 		Stored:    true,
 		SubType:   "string",
 		Type:      "list",
+	},
+	"FlowReportInterval": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "flowreportinterval",
+		ConvertedName:  "FlowReportInterval",
+		DefaultValue:   "30m",
+		Description:    `Frequency that flow report counts are upated.`,
+		Exposed:        true,
+		Name:           "flowReportInterval",
+		Stored:         true,
+		Type:           "string",
 	},
 	"IgnoreExpression": {
 		AllowedChoices: []string{},
@@ -1553,6 +1582,17 @@ traffic to the Kubernetes API, and using Microsegmentation for SSH only.`,
 		SubType:   "string",
 		Type:      "list",
 	},
+	"flowreportinterval": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "flowreportinterval",
+		ConvertedName:  "FlowReportInterval",
+		DefaultValue:   "30m",
+		Description:    `Frequency that flow report counts are upated.`,
+		Exposed:        true,
+		Name:           "flowReportInterval",
+		Stored:         true,
+		Type:           "string",
+	},
 	"ignoreexpression": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "ignoreexpression",
@@ -1959,6 +1999,9 @@ type SparseEnforcerProfile struct {
 	// traffic to the Kubernetes API, and using Microsegmentation for SSH only.
 	ExcludedNetworks *[]string `json:"excludedNetworks,omitempty" msgpack:"excludedNetworks,omitempty" bson:"excludednetworks,omitempty" mapstructure:"excludedNetworks,omitempty"`
 
+	// Frequency that flow report counts are upated.
+	FlowReportInterval *string `json:"flowReportInterval,omitempty" msgpack:"flowReportInterval,omitempty" bson:"flowreportinterval,omitempty" mapstructure:"flowReportInterval,omitempty"`
+
 	// A tag expression that identifies processing units to ignore. This can be
 	// useful to exclude `kube-system` pods, AWS EC2 agent pods, and third-party
 	// agents.
@@ -2108,6 +2151,9 @@ func (o *SparseEnforcerProfile) GetBSON() (interface{}, error) {
 	if o.ExcludedNetworks != nil {
 		s.ExcludedNetworks = o.ExcludedNetworks
 	}
+	if o.FlowReportInterval != nil {
+		s.FlowReportInterval = o.FlowReportInterval
+	}
 	if o.IgnoreExpression != nil {
 		s.IgnoreExpression = o.IgnoreExpression
 	}
@@ -2220,6 +2266,9 @@ func (o *SparseEnforcerProfile) SetBSON(raw bson.Raw) error {
 	if s.ExcludedNetworks != nil {
 		o.ExcludedNetworks = s.ExcludedNetworks
 	}
+	if s.FlowReportInterval != nil {
+		o.FlowReportInterval = s.FlowReportInterval
+	}
 	if s.IgnoreExpression != nil {
 		o.IgnoreExpression = s.IgnoreExpression
 	}
@@ -2329,6 +2378,9 @@ func (o *SparseEnforcerProfile) ToPlain() elemental.PlainIdentifiable {
 	}
 	if o.ExcludedNetworks != nil {
 		out.ExcludedNetworks = *o.ExcludedNetworks
+	}
+	if o.FlowReportInterval != nil {
+		out.FlowReportInterval = *o.FlowReportInterval
 	}
 	if o.IgnoreExpression != nil {
 		out.IgnoreExpression = *o.IgnoreExpression
@@ -2695,6 +2747,7 @@ type mongoAttributesEnforcerProfile struct {
 	Description                        string                                          `bson:"description"`
 	ExcludedInterfaces                 []string                                        `bson:"excludedinterfaces"`
 	ExcludedNetworks                   []string                                        `bson:"excludednetworks"`
+	FlowReportInterval                 string                                          `bson:"flowreportinterval"`
 	IgnoreExpression                   [][]string                                      `bson:"ignoreexpression"`
 	KubernetesMetadataExtractor        EnforcerProfileKubernetesMetadataExtractorValue `bson:"kubernetesmetadataextractor"`
 	KubernetesSupportEnabled           bool                                            `bson:"kubernetessupportenabled"`
@@ -2729,6 +2782,7 @@ type mongoAttributesSparseEnforcerProfile struct {
 	Description                        *string                                          `bson:"description,omitempty"`
 	ExcludedInterfaces                 *[]string                                        `bson:"excludedinterfaces,omitempty"`
 	ExcludedNetworks                   *[]string                                        `bson:"excludednetworks,omitempty"`
+	FlowReportInterval                 *string                                          `bson:"flowreportinterval,omitempty"`
 	IgnoreExpression                   *[][]string                                      `bson:"ignoreexpression,omitempty"`
 	KubernetesMetadataExtractor        *EnforcerProfileKubernetesMetadataExtractorValue `bson:"kubernetesmetadataextractor,omitempty"`
 	KubernetesSupportEnabled           *bool                                            `bson:"kubernetessupportenabled,omitempty"`

--- a/specs/enforcerprofile.spec
+++ b/specs/enforcerprofile.spec
@@ -64,6 +64,15 @@ attributes:
     stored: true
     orderable: true
 
+  - name: flowReportInterval
+    description: Frequency that flow report counts are upated.
+    type: string
+    exposed: true
+    stored: true
+    default_value: 30m
+    validations:
+    - $timeDuration
+
   - name: ignoreExpression
     description: |-
       A tag expression that identifies processing units to ignore. This can be


### PR DESCRIPTION
## Description

Adds flowReportInterval to enforcer profile, and defaults it to 30m.

## Motivation and Context

We are moving flow reporting interval from the enforcer command line to the enforcer profile.
https://redlock.atlassian.net/browse/CNS-3595

## How Has This Been Tested?

Added enforcer unit test for updating flow report interval via enforcer profile.
Manual testing against AIO backend with gaia changes.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
