### PR TITLE
neocna/improvement: change type of Data from string to []byte

### DIFF
--- a/azureresource.go
+++ b/azureresource.go
@@ -115,7 +115,7 @@ type AzureResource struct {
 	ID string `json:"ID" msgpack:"ID" bson:"-" mapstructure:"ID,omitempty"`
 
 	// The json-encoded data that represents the resource.
-	Data string `json:"data" msgpack:"data" bson:"data" mapstructure:"data,omitempty"`
+	Data []byte `json:"data" msgpack:"data" bson:"data" mapstructure:"data,omitempty"`
 
 	// The specific kind of the resource.
 	Kind AzureResourceKindValue `json:"kind" msgpack:"kind" bson:"kind" mapstructure:"kind,omitempty"`
@@ -161,6 +161,7 @@ func NewAzureResource() *AzureResource {
 
 	return &AzureResource{
 		ModelVersion:  1,
+		Data:          []byte{},
 		MigrationsLog: map[string]string{},
 		Tags:          []string{},
 	}
@@ -456,7 +457,7 @@ func (o *AzureResource) Validate() error {
 	errors := elemental.Errors{}
 	requiredErrors := elemental.Errors{}
 
-	if err := elemental.ValidateRequiredString("data", o.Data); err != nil {
+	if err := elemental.ValidateRequiredExternal("data", o.Data); err != nil {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
@@ -583,7 +584,8 @@ var AzureResourceAttributesMap = map[string]elemental.AttributeSpecification{
 		Name:           "data",
 		Required:       true,
 		Stored:         true,
-		Type:           "string",
+		SubType:        "[]byte",
+		Type:           "external",
 	},
 	"Kind": {
 		AllowedChoices: []string{"VirtualMachine", "NetworkInterface", "Subnet", "IPConfiguration"},
@@ -748,7 +750,8 @@ var AzureResourceLowerCaseAttributesMap = map[string]elemental.AttributeSpecific
 		Name:           "data",
 		Required:       true,
 		Stored:         true,
-		Type:           "string",
+		SubType:        "[]byte",
+		Type:           "external",
 	},
 	"kind": {
 		AllowedChoices: []string{"VirtualMachine", "NetworkInterface", "Subnet", "IPConfiguration"},
@@ -954,7 +957,7 @@ type SparseAzureResource struct {
 	ID *string `json:"ID,omitempty" msgpack:"ID,omitempty" bson:"-" mapstructure:"ID,omitempty"`
 
 	// The json-encoded data that represents the resource.
-	Data *string `json:"data,omitempty" msgpack:"data,omitempty" bson:"data,omitempty" mapstructure:"data,omitempty"`
+	Data *[]byte `json:"data,omitempty" msgpack:"data,omitempty" bson:"data,omitempty" mapstructure:"data,omitempty"`
 
 	// The specific kind of the resource.
 	Kind *AzureResourceKindValue `json:"kind,omitempty" msgpack:"kind,omitempty" bson:"kind,omitempty" mapstructure:"kind,omitempty"`
@@ -1276,7 +1279,7 @@ func (o *SparseAzureResource) DeepCopyInto(out *SparseAzureResource) {
 
 type mongoAttributesAzureResource struct {
 	ID             bson.ObjectId              `bson:"_id,omitempty"`
-	Data           string                     `bson:"data"`
+	Data           []byte                     `bson:"data"`
 	Kind           AzureResourceKindValue     `bson:"kind"`
 	MigrationsLog  map[string]string          `bson:"migrationslog,omitempty"`
 	Name           string                     `bson:"name"`
@@ -1291,7 +1294,7 @@ type mongoAttributesAzureResource struct {
 }
 type mongoAttributesSparseAzureResource struct {
 	ID             bson.ObjectId               `bson:"_id,omitempty"`
-	Data           *string                     `bson:"data,omitempty"`
+	Data           *[]byte                     `bson:"data,omitempty"`
 	Kind           *AzureResourceKindValue     `bson:"kind,omitempty"`
 	MigrationsLog  *map[string]string          `bson:"migrationslog,omitempty"`
 	Name           *string                     `bson:"name,omitempty"`

--- a/specs/azureresource.spec
+++ b/specs/azureresource.spec
@@ -26,8 +26,9 @@ attributes:
   v1:
   - name: data
     description: The json-encoded data that represents the resource.
-    type: string
+    type: external
     exposed: true
+    subtype: '[]byte'
     stored: true
     required: true
     example_value: |-


### PR DESCRIPTION
There is no reason to store the raw AzureResource's data as a `string`. This is because this field has no purpose other than passing its data to a json decoder/unmrashaler, which requires `[]byte`. In Go, `string` is immutable type. This means a statement like `[]byte(str)`, will trigger a copy of `str` since `[]byte` is mutable. To avoid this unnecessary allocation, we simply deal with the `[]byte` type.

This is the first instance in our models to have a stored field of type `[]byte`. I verified that it works correctly. Checking the stored field shows that raw bytes are stored as binary data and displayed as base64.

The following is an example of AzureResource stored via a mongo manipulator:
```
{ "_id" : ObjectId("623b7d95d62b9944c1e9ba2f"), "data" : BinData(0,"ICAgIHsKCQkgICAgICAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwL3Jlc291cmNlR3JvdXBzL2dyb3VwMS9wcm92aWRlcnMvTWljcm9zb2Z0LkNvbXB1dGUvdmlydHVhbE1hY2hpbmVzL3ZtMSIsCgkJICAgICAgInZtSWQiOiAiMTExMTExMTEtMTExMS0xMTExLTExMTEtMTExMTExMTExMTExIiwKCQkgICAgICAibG9jYXRpb24iOiAiZWFzdHVzIiwKCQkgICAgICAicG93ZXJTdGF0ZSI6ICJQb3dlclN0YXRlL3J1bm5pbmciLAoJCSAgICAgICJwcm9wZXJ0aWVzLm5ldHdvcmtQcm9maWxlIjogewoJCSAgICAgICAgIm5ldHdvcmtJbnRlcmZhY2VzIjogWwoJCSAgICAgICAgICB7CgkJICAgICAgICAgICAgImlkIjogIi9zdWJzY3JpcHRpb25zLzAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMC9yZXNvdXJjZUdyb3Vwcy9ncm91cDEvcHJvdmlkZXJzL01pY3Jvc29mdC5OZXR3b3JrL25ldHdvcmtJbnRlcmZhY2VzL25pYzEiLAoJCSAgICAgICAgICAgICJpcENvbmZpZ3VyYXRpb25zIjogWwoJCSAgICAgICAgICAgICAgewoJCSAgICAgICAgICAgICAgICAiaWQiOiAiL3N1YnNjcmlwdGlvbnMvMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwL3Jlc291cmNlR3JvdXBzL2dyb3VwMS9wcm92aWRlcnMvTWljcm9zb2Z0Lk5ldHdvcmsvbmV0d29ya0ludGVyZmFjZXMvbmljMS9pcENvbmZpZ3VyYXRpb25zL2lwY29uZmlnMSIsCgkJICAgICAgICAgICAgICAgICJuYW1lIjogImlwY29uZmlnMSIsCgkJICAgICAgICAgICAgICAgICJwcmltYXJ5IjogdHJ1ZSwKCQkgICAgICAgICAgICAgICAgInByaXZhdGVJcEFkZHJlc3MiOiAiMTkyLjE2OC4wLjQiCgkJICAgICAgICAgICAgICB9CgkJICAgICAgICAgICAgXSwKCQkgICAgICAgICAgICAicHJpdmF0ZUlwQWRkcmVzcyI6ICIxOTIuMTY4LjAuNCIKCQkgICAgICAgICAgfQoJCSAgICAgICAgXQoJCSAgICAgIH0KCQkgICAgfQ=="), "kind" : "VirtualMachine", "name" : "vm1", "namespace" : "/", "provider" : "MicrosoftCompute", "resourcegroup" : "group1", "resourceid" : "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/virtualMachines/vm1", "subscriptionid" : "00000000-0000-0000-0000-000000000000", "tags" : [ "privateip=192.168.0.4", "vmid=11111111-1111-1111-1111-111111111111", "location=eatus", "powerstate=PowerState/running" ], "zhash" : NumberLong("5132652968573252509"), "zone" : 0 }
```