### PR TITLE
Update: PaaS support

### DIFF
--- a/cloudnetworkqueryfilter.go
+++ b/cloudnetworkqueryfilter.go
@@ -21,6 +21,9 @@ const (
 	// CloudNetworkQueryFilterResourceTypeInterface represents the value Interface.
 	CloudNetworkQueryFilterResourceTypeInterface CloudNetworkQueryFilterResourceTypeValue = "Interface"
 
+	// CloudNetworkQueryFilterResourceTypePaaS represents the value PaaS.
+	CloudNetworkQueryFilterResourceTypePaaS CloudNetworkQueryFilterResourceTypeValue = "PaaS"
+
 	// CloudNetworkQueryFilterResourceTypeProcessingUnit represents the value ProcessingUnit.
 	CloudNetworkQueryFilterResourceTypeProcessingUnit CloudNetworkQueryFilterResourceTypeValue = "ProcessingUnit"
 
@@ -48,6 +51,9 @@ type CloudNetworkQueryFilter struct {
 	// the fields are ignored. An object ID can refer to an instance, VPC endpoint, or
 	// network interface.
 	ObjectIDs []string `json:"objectIDs,omitempty" msgpack:"objectIDs,omitempty" bson:"objectids,omitempty" mapstructure:"objectIDs,omitempty"`
+
+	// Identifies a list of for Platform as a Service types.
+	PaasTypes []string `json:"paasTypes,omitempty" msgpack:"paasTypes,omitempty" bson:"paastypes,omitempty" mapstructure:"paasTypes,omitempty"`
 
 	// Restricts the query on only endpoints with the given productInfoType.
 	ProductInfoType string `json:"productInfoType,omitempty" msgpack:"productInfoType,omitempty" bson:"productinfotype,omitempty" mapstructure:"productInfoType,omitempty"`
@@ -104,11 +110,12 @@ func NewCloudNetworkQueryFilter() *CloudNetworkQueryFilter {
 		CloudTypes:    []string{},
 		ImageIDs:      []string{},
 		ObjectIDs:     []string{},
-		ServiceOwners: []string{},
+		PaasTypes:     []string{},
+		SecurityTags:  []string{},
 		Regions:       []string{},
 		ResourceType:  CloudNetworkQueryFilterResourceTypeInstance,
-		SecurityTags:  []string{},
 		ServiceNames:  []string{},
+		ServiceOwners: []string{},
 		ServiceTypes:  []string{},
 		Subnets:       []string{},
 		Tags:          []string{},
@@ -131,6 +138,7 @@ func (o *CloudNetworkQueryFilter) GetBSON() (interface{}, error) {
 	s.CloudTypes = o.CloudTypes
 	s.ImageIDs = o.ImageIDs
 	s.ObjectIDs = o.ObjectIDs
+	s.PaasTypes = o.PaasTypes
 	s.ProductInfoType = o.ProductInfoType
 	s.ProductInfoValue = o.ProductInfoValue
 	s.Regions = o.Regions
@@ -164,6 +172,7 @@ func (o *CloudNetworkQueryFilter) SetBSON(raw bson.Raw) error {
 	o.CloudTypes = s.CloudTypes
 	o.ImageIDs = s.ImageIDs
 	o.ObjectIDs = s.ObjectIDs
+	o.PaasTypes = s.PaasTypes
 	o.ProductInfoType = s.ProductInfoType
 	o.ProductInfoValue = s.ProductInfoValue
 	o.Regions = s.Regions
@@ -219,7 +228,7 @@ func (o *CloudNetworkQueryFilter) Validate() error {
 		requiredErrors = requiredErrors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("resourceType", string(o.ResourceType), []string{"Instance", "Interface", "Service", "ProcessingUnit"}, false); err != nil {
+	if err := elemental.ValidateStringInList("resourceType", string(o.ResourceType), []string{"Instance", "Interface", "Service", "ProcessingUnit", "PaaS"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -267,6 +276,8 @@ func (o *CloudNetworkQueryFilter) ValueForAttribute(name string) interface{} {
 		return o.ImageIDs
 	case "objectIDs":
 		return o.ObjectIDs
+	case "paasTypes":
+		return o.PaasTypes
 	case "productInfoType":
 		return o.ProductInfoType
 	case "productInfoValue":
@@ -355,6 +366,17 @@ network interface.`,
 		SubType: "string",
 		Type:    "list",
 	},
+	"PaasTypes": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "paastypes",
+		ConvertedName:  "PaasTypes",
+		Description:    `Identifies a list of for Platform as a Service types.`,
+		Exposed:        true,
+		Name:           "paasTypes",
+		Stored:         true,
+		SubType:        "string",
+		Type:           "list",
+	},
 	"ProductInfoType": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "productinfotype",
@@ -398,7 +420,7 @@ not apply to other resource types.`,
 		Type:           "string",
 	},
 	"ResourceType": {
-		AllowedChoices: []string{"Instance", "Interface", "Service", "ProcessingUnit"},
+		AllowedChoices: []string{"Instance", "Interface", "Service", "ProcessingUnit", "PaaS"},
 		BSONFieldName:  "resourcetype",
 		ConvertedName:  "ResourceType",
 		DefaultValue:   CloudNetworkQueryFilterResourceTypeInstance,
@@ -547,6 +569,17 @@ network interface.`,
 		SubType: "string",
 		Type:    "list",
 	},
+	"paastypes": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "paastypes",
+		ConvertedName:  "PaasTypes",
+		Description:    `Identifies a list of for Platform as a Service types.`,
+		Exposed:        true,
+		Name:           "paasTypes",
+		Stored:         true,
+		SubType:        "string",
+		Type:           "list",
+	},
 	"productinfotype": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "productinfotype",
@@ -590,7 +623,7 @@ not apply to other resource types.`,
 		Type:           "string",
 	},
 	"resourcetype": {
-		AllowedChoices: []string{"Instance", "Interface", "Service", "ProcessingUnit"},
+		AllowedChoices: []string{"Instance", "Interface", "Service", "ProcessingUnit", "PaaS"},
 		BSONFieldName:  "resourcetype",
 		ConvertedName:  "ResourceType",
 		DefaultValue:   CloudNetworkQueryFilterResourceTypeInstance,
@@ -684,6 +717,7 @@ type mongoAttributesCloudNetworkQueryFilter struct {
 	CloudTypes       []string                                 `bson:"cloudtypes,omitempty"`
 	ImageIDs         []string                                 `bson:"imageids,omitempty"`
 	ObjectIDs        []string                                 `bson:"objectids,omitempty"`
+	PaasTypes        []string                                 `bson:"paastypes,omitempty"`
 	ProductInfoType  string                                   `bson:"productinfotype,omitempty"`
 	ProductInfoValue string                                   `bson:"productinfovalue,omitempty"`
 	Regions          []string                                 `bson:"regions,omitempty"`

--- a/cloudnetworkqueryfilter.go
+++ b/cloudnetworkqueryfilter.go
@@ -52,7 +52,7 @@ type CloudNetworkQueryFilter struct {
 	// network interface.
 	ObjectIDs []string `json:"objectIDs,omitempty" msgpack:"objectIDs,omitempty" bson:"objectids,omitempty" mapstructure:"objectIDs,omitempty"`
 
-	// Identifies a list of for Platform as a Service types.
+	// Identifies a list of Platform as a Service types.
 	PaasTypes []string `json:"paasTypes,omitempty" msgpack:"paasTypes,omitempty" bson:"paastypes,omitempty" mapstructure:"paasTypes,omitempty"`
 
 	// Restricts the query on only endpoints with the given productInfoType.
@@ -370,7 +370,7 @@ network interface.`,
 		AllowedChoices: []string{},
 		BSONFieldName:  "paastypes",
 		ConvertedName:  "PaasTypes",
-		Description:    `Identifies a list of for Platform as a Service types.`,
+		Description:    `Identifies a list of Platform as a Service types.`,
 		Exposed:        true,
 		Name:           "paasTypes",
 		Stored:         true,
@@ -573,7 +573,7 @@ network interface.`,
 		AllowedChoices: []string{},
 		BSONFieldName:  "paastypes",
 		ConvertedName:  "PaasTypes",
-		Description:    `Identifies a list of for Platform as a Service types.`,
+		Description:    `Identifies a list of Platform as a Service types.`,
 		Exposed:        true,
 		Name:           "paasTypes",
 		Stored:         true,

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -5010,11 +5010,26 @@ func TestValidateCloudGraphQuery(t *testing.T) {
 					DestinationSelector: &CloudNetworkQueryFilter{
 						ResourceType: CloudNetworkQueryFilterResourceTypePaaS,
 						CloudTypes:   []string{"Aws"},
-						PaasTypes:    []string{"sql"},
+						PaasTypes:    []string{"MicrosoftDBforMySQLFlexibleServers"},
 					},
 				},
 			},
 			true,
+		},
+		{
+			"paas filter is set for Azure",
+			args{
+				"invalid",
+				&CloudNetworkQuery{
+					SourceIP: "1.1.1.0/24",
+					DestinationSelector: &CloudNetworkQueryFilter{
+						ResourceType: CloudNetworkQueryFilterResourceTypePaaS,
+						CloudTypes:   []string{"Azure"},
+						PaasTypes:    []string{"sql"},
+					},
+				},
+			},
+			false,
 		},
 	}
 

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -4971,6 +4971,51 @@ func TestValidateCloudGraphQuery(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"paas filter is set for source selector",
+			args{
+				"invalid",
+				&CloudNetworkQuery{
+					SourceSelector: &CloudNetworkQueryFilter{
+						ResourceType: CloudNetworkQueryFilterResourceTypeInterface,
+						CloudTypes:   []string{"Azure"},
+						PaasTypes:    []string{"sql"},
+					},
+					DestinationIP: "1.1.1.0/24",
+				},
+			},
+			true,
+		},
+		{
+			"paas filter is not empty but resource type is not paas",
+			args{
+				"invalid",
+				&CloudNetworkQuery{
+					SourceIP: "1.1.1.0/24",
+					DestinationSelector: &CloudNetworkQueryFilter{
+						ResourceType: CloudNetworkQueryFilterResourceTypeInstance,
+						CloudTypes:   []string{"Azure"},
+						PaasTypes:    []string{"sql"},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"paas filter is set for AWS",
+			args{
+				"invalid",
+				&CloudNetworkQuery{
+					SourceIP: "1.1.1.0/24",
+					DestinationSelector: &CloudNetworkQueryFilter{
+						ResourceType: CloudNetworkQueryFilterResourceTypePaaS,
+						CloudTypes:   []string{"Aws"},
+						PaasTypes:    []string{"sql"},
+					},
+				},
+			},
+			true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -11876,6 +11876,12 @@ The exact object that the search applies. If ObjectIDs are defined, the rest of
 the fields are ignored. An object ID can refer to an instance, VPC endpoint, or
 network interface.
 
+##### `paasTypes`
+
+Type: `[]string`
+
+Identifies a list of for Platform as a Service types.
+
 ##### `productInfoType`
 
 Type: `string`
@@ -11903,7 +11909,7 @@ The status of the resource.
 
 ##### `resourceType` [`required`]
 
-Type: `enum(Instance | Interface | Service | ProcessingUnit)`
+Type: `enum(Instance | Interface | Service | ProcessingUnit | PaaS)`
 
 The type of endpoint resource. The resource type is a mandatory field and a
 query cannot span multiple resource types.

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -11880,7 +11880,7 @@ network interface.
 
 Type: `[]string`
 
-Identifies a list of for Platform as a Service types.
+Identifies a list of Platform as a Service types.
 
 ##### `productInfoType`
 

--- a/openapi3_autogen/cloudnetworkqueryfilter.json
+++ b/openapi3_autogen/cloudnetworkqueryfilter.json
@@ -47,7 +47,7 @@
             "type": "array"
           },
           "paasTypes": {
-            "description": "Identifies a list of for Platform as a Service types.",
+            "description": "Identifies a list of Platform as a Service types.",
             "items": {
               "type": "string"
             },

--- a/openapi3_autogen/cloudnetworkqueryfilter.json
+++ b/openapi3_autogen/cloudnetworkqueryfilter.json
@@ -46,6 +46,13 @@
             },
             "type": "array"
           },
+          "paasTypes": {
+            "description": "Identifies a list of for Platform as a Service types.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "productInfoType": {
             "description": "Restricts the query on only endpoints with the given productInfoType.",
             "type": "string"
@@ -76,7 +83,8 @@
               "Instance",
               "Interface",
               "Service",
-              "ProcessingUnit"
+              "ProcessingUnit",
+              "PaaS"
             ]
           },
           "securityTags": {

--- a/specs/+cloudnetworkqueryfilter.spec
+++ b/specs/+cloudnetworkqueryfilter.spec
@@ -65,7 +65,7 @@ attributes:
     omit_empty: true
 
   - name: paasTypes
-    description: Identifies a list of for Platform as a Service types.
+    description: Identifies a list of Platform as a Service types.
     type: list
     exposed: true
     subtype: string

--- a/specs/+cloudnetworkqueryfilter.spec
+++ b/specs/+cloudnetworkqueryfilter.spec
@@ -64,6 +64,14 @@ attributes:
     stored: true
     omit_empty: true
 
+  - name: paasTypes
+    description: Identifies a list of for Platform as a Service types.
+    type: list
+    exposed: true
+    subtype: string
+    stored: true
+    omit_empty: true
+
   - name: productInfoType
     description: Restricts the query on only endpoints with the given productInfoType.
     type: string
@@ -111,6 +119,7 @@ attributes:
     - Interface
     - Service
     - ProcessingUnit
+    - PaaS
     default_value: Instance
 
   - name: securityTags


### PR DESCRIPTION
Add PaaS related attributes.

The reason we are creating new attributes instead of reusing the `servcieName` is that we need to have one to one mapping between the new `paas` RQL filter and the cloud query filter object. If we reuse `serviceName`, we cannot easily convert cloud query filter object back to `paas` RQL.