### PR TITLE
fix: alert flip flops

### DIFF
--- a/cloudschedulednetworkquery.go
+++ b/cloudschedulednetworkquery.go
@@ -124,7 +124,7 @@ type CloudScheduledNetworkQuery struct {
 	SuccessfulExecutionTimestamp time.Time `json:"successfulExecutionTimestamp" msgpack:"successfulExecutionTimestamp" bson:"successfulexecutiontimestamp" mapstructure:"successfulExecutionTimestamp,omitempty"`
 
 	// Mapping of last successful execution timestamp for every account.
-	SuccessfulExecutionTimestampMap map[string]string `json:"successfulExecutionTimestampMap" msgpack:"successfulExecutionTimestampMap" bson:"successfulexecutiontimestampmap" mapstructure:"successfulExecutionTimestampMap,omitempty"`
+	SuccessfulExecutionTimestampMap map[string]time.Time `json:"successfulExecutionTimestampMap" msgpack:"successfulExecutionTimestampMap" bson:"successfulexecutiontimestampmap" mapstructure:"successfulExecutionTimestampMap,omitempty"`
 
 	// Prisma ID of the tenant in which the Alert Rule is created.
 	TenantPrismaID string `json:"tenantPrismaID" msgpack:"tenantPrismaID" bson:"tenantprismaid" mapstructure:"tenantPrismaID,omitempty"`
@@ -149,7 +149,7 @@ func NewCloudScheduledNetworkQuery() *CloudScheduledNetworkQuery {
 		ModelVersion:                    1,
 		CloudNetworkQuery:               NewCloudNetworkQuery(),
 		MigrationsLog:                   map[string]string{},
-		SuccessfulExecutionTimestampMap: map[string]string{},
+		SuccessfulExecutionTimestampMap: map[string]time.Time{},
 	}
 }
 
@@ -759,7 +759,7 @@ obtained.`,
 		Exposed:        true,
 		Name:           "successfulExecutionTimestampMap",
 		Stored:         true,
-		SubType:        "map[string]string",
+		SubType:        "map[string]time",
 		Type:           "external",
 	},
 	"TenantPrismaID": {
@@ -977,7 +977,7 @@ obtained.`,
 		Exposed:        true,
 		Name:           "successfulExecutionTimestampMap",
 		Stored:         true,
-		SubType:        "map[string]string",
+		SubType:        "map[string]time",
 		Type:           "external",
 	},
 	"tenantprismaid": {
@@ -1139,7 +1139,7 @@ type SparseCloudScheduledNetworkQuery struct {
 	SuccessfulExecutionTimestamp *time.Time `json:"successfulExecutionTimestamp,omitempty" msgpack:"successfulExecutionTimestamp,omitempty" bson:"successfulexecutiontimestamp,omitempty" mapstructure:"successfulExecutionTimestamp,omitempty"`
 
 	// Mapping of last successful execution timestamp for every account.
-	SuccessfulExecutionTimestampMap *map[string]string `json:"successfulExecutionTimestampMap,omitempty" msgpack:"successfulExecutionTimestampMap,omitempty" bson:"successfulexecutiontimestampmap,omitempty" mapstructure:"successfulExecutionTimestampMap,omitempty"`
+	SuccessfulExecutionTimestampMap *map[string]time.Time `json:"successfulExecutionTimestampMap,omitempty" msgpack:"successfulExecutionTimestampMap,omitempty" bson:"successfulexecutiontimestampmap,omitempty" mapstructure:"successfulExecutionTimestampMap,omitempty"`
 
 	// Prisma ID of the tenant in which the Alert Rule is created.
 	TenantPrismaID *string `json:"tenantPrismaID,omitempty" msgpack:"tenantPrismaID,omitempty" bson:"tenantprismaid,omitempty" mapstructure:"tenantPrismaID,omitempty"`
@@ -1515,38 +1515,38 @@ func (o *SparseCloudScheduledNetworkQuery) DeepCopyInto(out *SparseCloudSchedule
 }
 
 type mongoAttributesCloudScheduledNetworkQuery struct {
-	ID                              bson.ObjectId      `bson:"_id,omitempty"`
-	CloudNetworkQuery               *CloudNetworkQuery `bson:"cloudnetworkquery"`
-	CreateTime                      time.Time          `bson:"createtime"`
-	Disabled                        bool               `bson:"disabled"`
-	LastExecutionTimestamp          time.Time          `bson:"lastexecutiontimestamp"`
-	MigrationsLog                   map[string]string  `bson:"migrationslog,omitempty"`
-	Name                            string             `bson:"name"`
-	Namespace                       string             `bson:"namespace"`
-	PrismaCloudAlertRuleID          string             `bson:"prismacloudalertruleid"`
-	PrismaCloudPolicyID             string             `bson:"prismacloudpolicyid"`
-	SuccessfulExecutionTimestamp    time.Time          `bson:"successfulexecutiontimestamp"`
-	SuccessfulExecutionTimestampMap map[string]string  `bson:"successfulexecutiontimestampmap"`
-	TenantPrismaID                  string             `bson:"tenantprismaid"`
-	UpdateTime                      time.Time          `bson:"updatetime"`
-	ZHash                           int                `bson:"zhash"`
-	Zone                            int                `bson:"zone"`
+	ID                              bson.ObjectId        `bson:"_id,omitempty"`
+	CloudNetworkQuery               *CloudNetworkQuery   `bson:"cloudnetworkquery"`
+	CreateTime                      time.Time            `bson:"createtime"`
+	Disabled                        bool                 `bson:"disabled"`
+	LastExecutionTimestamp          time.Time            `bson:"lastexecutiontimestamp"`
+	MigrationsLog                   map[string]string    `bson:"migrationslog,omitempty"`
+	Name                            string               `bson:"name"`
+	Namespace                       string               `bson:"namespace"`
+	PrismaCloudAlertRuleID          string               `bson:"prismacloudalertruleid"`
+	PrismaCloudPolicyID             string               `bson:"prismacloudpolicyid"`
+	SuccessfulExecutionTimestamp    time.Time            `bson:"successfulexecutiontimestamp"`
+	SuccessfulExecutionTimestampMap map[string]time.Time `bson:"successfulexecutiontimestampmap"`
+	TenantPrismaID                  string               `bson:"tenantprismaid"`
+	UpdateTime                      time.Time            `bson:"updatetime"`
+	ZHash                           int                  `bson:"zhash"`
+	Zone                            int                  `bson:"zone"`
 }
 type mongoAttributesSparseCloudScheduledNetworkQuery struct {
-	ID                              bson.ObjectId      `bson:"_id,omitempty"`
-	CloudNetworkQuery               *CloudNetworkQuery `bson:"cloudnetworkquery,omitempty"`
-	CreateTime                      *time.Time         `bson:"createtime,omitempty"`
-	Disabled                        *bool              `bson:"disabled,omitempty"`
-	LastExecutionTimestamp          *time.Time         `bson:"lastexecutiontimestamp,omitempty"`
-	MigrationsLog                   *map[string]string `bson:"migrationslog,omitempty"`
-	Name                            *string            `bson:"name,omitempty"`
-	Namespace                       *string            `bson:"namespace,omitempty"`
-	PrismaCloudAlertRuleID          *string            `bson:"prismacloudalertruleid,omitempty"`
-	PrismaCloudPolicyID             *string            `bson:"prismacloudpolicyid,omitempty"`
-	SuccessfulExecutionTimestamp    *time.Time         `bson:"successfulexecutiontimestamp,omitempty"`
-	SuccessfulExecutionTimestampMap *map[string]string `bson:"successfulexecutiontimestampmap,omitempty"`
-	TenantPrismaID                  *string            `bson:"tenantprismaid,omitempty"`
-	UpdateTime                      *time.Time         `bson:"updatetime,omitempty"`
-	ZHash                           *int               `bson:"zhash,omitempty"`
-	Zone                            *int               `bson:"zone,omitempty"`
+	ID                              bson.ObjectId         `bson:"_id,omitempty"`
+	CloudNetworkQuery               *CloudNetworkQuery    `bson:"cloudnetworkquery,omitempty"`
+	CreateTime                      *time.Time            `bson:"createtime,omitempty"`
+	Disabled                        *bool                 `bson:"disabled,omitempty"`
+	LastExecutionTimestamp          *time.Time            `bson:"lastexecutiontimestamp,omitempty"`
+	MigrationsLog                   *map[string]string    `bson:"migrationslog,omitempty"`
+	Name                            *string               `bson:"name,omitempty"`
+	Namespace                       *string               `bson:"namespace,omitempty"`
+	PrismaCloudAlertRuleID          *string               `bson:"prismacloudalertruleid,omitempty"`
+	PrismaCloudPolicyID             *string               `bson:"prismacloudpolicyid,omitempty"`
+	SuccessfulExecutionTimestamp    *time.Time            `bson:"successfulexecutiontimestamp,omitempty"`
+	SuccessfulExecutionTimestampMap *map[string]time.Time `bson:"successfulexecutiontimestampmap,omitempty"`
+	TenantPrismaID                  *string               `bson:"tenantprismaid,omitempty"`
+	UpdateTime                      *time.Time            `bson:"updatetime,omitempty"`
+	ZHash                           *int                  `bson:"zhash,omitempty"`
+	Zone                            *int                  `bson:"zone,omitempty"`
 }

--- a/cloudschedulednetworkquery.go
+++ b/cloudschedulednetworkquery.go
@@ -123,6 +123,9 @@ type CloudScheduledNetworkQuery struct {
 	// obtained.
 	SuccessfulExecutionTimestamp time.Time `json:"successfulExecutionTimestamp" msgpack:"successfulExecutionTimestamp" bson:"successfulexecutiontimestamp" mapstructure:"successfulExecutionTimestamp,omitempty"`
 
+	// Mapping of last successful execution timestamp for every account.
+	SuccessfulExecutionTimestampMap map[string]string `json:"successfulExecutionTimestampMap" msgpack:"successfulExecutionTimestampMap" bson:"successfulexecutiontimestampmap" mapstructure:"successfulExecutionTimestampMap,omitempty"`
+
 	// Prisma ID of the tenant in which the Alert Rule is created.
 	TenantPrismaID string `json:"tenantPrismaID" msgpack:"tenantPrismaID" bson:"tenantprismaid" mapstructure:"tenantPrismaID,omitempty"`
 
@@ -143,9 +146,10 @@ type CloudScheduledNetworkQuery struct {
 func NewCloudScheduledNetworkQuery() *CloudScheduledNetworkQuery {
 
 	return &CloudScheduledNetworkQuery{
-		ModelVersion:      1,
-		CloudNetworkQuery: NewCloudNetworkQuery(),
-		MigrationsLog:     map[string]string{},
+		ModelVersion:                    1,
+		CloudNetworkQuery:               NewCloudNetworkQuery(),
+		MigrationsLog:                   map[string]string{},
+		SuccessfulExecutionTimestampMap: map[string]string{},
 	}
 }
 
@@ -190,6 +194,7 @@ func (o *CloudScheduledNetworkQuery) GetBSON() (interface{}, error) {
 	s.PrismaCloudAlertRuleID = o.PrismaCloudAlertRuleID
 	s.PrismaCloudPolicyID = o.PrismaCloudPolicyID
 	s.SuccessfulExecutionTimestamp = o.SuccessfulExecutionTimestamp
+	s.SuccessfulExecutionTimestampMap = o.SuccessfulExecutionTimestampMap
 	s.TenantPrismaID = o.TenantPrismaID
 	s.UpdateTime = o.UpdateTime
 	s.ZHash = o.ZHash
@@ -222,6 +227,7 @@ func (o *CloudScheduledNetworkQuery) SetBSON(raw bson.Raw) error {
 	o.PrismaCloudAlertRuleID = s.PrismaCloudAlertRuleID
 	o.PrismaCloudPolicyID = s.PrismaCloudPolicyID
 	o.SuccessfulExecutionTimestamp = s.SuccessfulExecutionTimestamp
+	o.SuccessfulExecutionTimestampMap = s.SuccessfulExecutionTimestampMap
 	o.TenantPrismaID = s.TenantPrismaID
 	o.UpdateTime = s.UpdateTime
 	o.ZHash = s.ZHash
@@ -353,22 +359,23 @@ func (o *CloudScheduledNetworkQuery) ToSparse(fields ...string) elemental.Sparse
 	if len(fields) == 0 {
 		// nolint: goimports
 		return &SparseCloudScheduledNetworkQuery{
-			ID:                           &o.ID,
-			CloudGraphResultID:           &o.CloudGraphResultID,
-			CloudNetworkQuery:            o.CloudNetworkQuery,
-			CreateTime:                   &o.CreateTime,
-			Disabled:                     &o.Disabled,
-			LastExecutionTimestamp:       &o.LastExecutionTimestamp,
-			MigrationsLog:                &o.MigrationsLog,
-			Name:                         &o.Name,
-			Namespace:                    &o.Namespace,
-			PrismaCloudAlertRuleID:       &o.PrismaCloudAlertRuleID,
-			PrismaCloudPolicyID:          &o.PrismaCloudPolicyID,
-			SuccessfulExecutionTimestamp: &o.SuccessfulExecutionTimestamp,
-			TenantPrismaID:               &o.TenantPrismaID,
-			UpdateTime:                   &o.UpdateTime,
-			ZHash:                        &o.ZHash,
-			Zone:                         &o.Zone,
+			ID:                              &o.ID,
+			CloudGraphResultID:              &o.CloudGraphResultID,
+			CloudNetworkQuery:               o.CloudNetworkQuery,
+			CreateTime:                      &o.CreateTime,
+			Disabled:                        &o.Disabled,
+			LastExecutionTimestamp:          &o.LastExecutionTimestamp,
+			MigrationsLog:                   &o.MigrationsLog,
+			Name:                            &o.Name,
+			Namespace:                       &o.Namespace,
+			PrismaCloudAlertRuleID:          &o.PrismaCloudAlertRuleID,
+			PrismaCloudPolicyID:             &o.PrismaCloudPolicyID,
+			SuccessfulExecutionTimestamp:    &o.SuccessfulExecutionTimestamp,
+			SuccessfulExecutionTimestampMap: &o.SuccessfulExecutionTimestampMap,
+			TenantPrismaID:                  &o.TenantPrismaID,
+			UpdateTime:                      &o.UpdateTime,
+			ZHash:                           &o.ZHash,
+			Zone:                            &o.Zone,
 		}
 	}
 
@@ -399,6 +406,8 @@ func (o *CloudScheduledNetworkQuery) ToSparse(fields ...string) elemental.Sparse
 			sp.PrismaCloudPolicyID = &(o.PrismaCloudPolicyID)
 		case "successfulExecutionTimestamp":
 			sp.SuccessfulExecutionTimestamp = &(o.SuccessfulExecutionTimestamp)
+		case "successfulExecutionTimestampMap":
+			sp.SuccessfulExecutionTimestampMap = &(o.SuccessfulExecutionTimestampMap)
 		case "tenantPrismaID":
 			sp.TenantPrismaID = &(o.TenantPrismaID)
 		case "updateTime":
@@ -455,6 +464,9 @@ func (o *CloudScheduledNetworkQuery) Patch(sparse elemental.SparseIdentifiable) 
 	}
 	if so.SuccessfulExecutionTimestamp != nil {
 		o.SuccessfulExecutionTimestamp = *so.SuccessfulExecutionTimestamp
+	}
+	if so.SuccessfulExecutionTimestampMap != nil {
+		o.SuccessfulExecutionTimestampMap = *so.SuccessfulExecutionTimestampMap
 	}
 	if so.TenantPrismaID != nil {
 		o.TenantPrismaID = *so.TenantPrismaID
@@ -573,6 +585,8 @@ func (o *CloudScheduledNetworkQuery) ValueForAttribute(name string) interface{} 
 		return o.PrismaCloudPolicyID
 	case "successfulExecutionTimestamp":
 		return o.SuccessfulExecutionTimestamp
+	case "successfulExecutionTimestampMap":
+		return o.SuccessfulExecutionTimestampMap
 	case "tenantPrismaID":
 		return o.TenantPrismaID
 	case "updateTime":
@@ -736,6 +750,17 @@ obtained.`,
 		Orderable: true,
 		Stored:    true,
 		Type:      "time",
+	},
+	"SuccessfulExecutionTimestampMap": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "successfulexecutiontimestampmap",
+		ConvertedName:  "SuccessfulExecutionTimestampMap",
+		Description:    `Mapping of last successful execution timestamp for every account.`,
+		Exposed:        true,
+		Name:           "successfulExecutionTimestampMap",
+		Stored:         true,
+		SubType:        "map[string]string",
+		Type:           "external",
 	},
 	"TenantPrismaID": {
 		AllowedChoices: []string{},
@@ -944,6 +969,17 @@ obtained.`,
 		Stored:    true,
 		Type:      "time",
 	},
+	"successfulexecutiontimestampmap": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "successfulexecutiontimestampmap",
+		ConvertedName:  "SuccessfulExecutionTimestampMap",
+		Description:    `Mapping of last successful execution timestamp for every account.`,
+		Exposed:        true,
+		Name:           "successfulExecutionTimestampMap",
+		Stored:         true,
+		SubType:        "map[string]string",
+		Type:           "external",
+	},
 	"tenantprismaid": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "tenantprismaid",
@@ -1102,6 +1138,9 @@ type SparseCloudScheduledNetworkQuery struct {
 	// obtained.
 	SuccessfulExecutionTimestamp *time.Time `json:"successfulExecutionTimestamp,omitempty" msgpack:"successfulExecutionTimestamp,omitempty" bson:"successfulexecutiontimestamp,omitempty" mapstructure:"successfulExecutionTimestamp,omitempty"`
 
+	// Mapping of last successful execution timestamp for every account.
+	SuccessfulExecutionTimestampMap *map[string]string `json:"successfulExecutionTimestampMap,omitempty" msgpack:"successfulExecutionTimestampMap,omitempty" bson:"successfulexecutiontimestampmap,omitempty" mapstructure:"successfulExecutionTimestampMap,omitempty"`
+
 	// Prisma ID of the tenant in which the Alert Rule is created.
 	TenantPrismaID *string `json:"tenantPrismaID,omitempty" msgpack:"tenantPrismaID,omitempty" bson:"tenantprismaid,omitempty" mapstructure:"tenantPrismaID,omitempty"`
 
@@ -1191,6 +1230,9 @@ func (o *SparseCloudScheduledNetworkQuery) GetBSON() (interface{}, error) {
 	if o.SuccessfulExecutionTimestamp != nil {
 		s.SuccessfulExecutionTimestamp = o.SuccessfulExecutionTimestamp
 	}
+	if o.SuccessfulExecutionTimestampMap != nil {
+		s.SuccessfulExecutionTimestampMap = o.SuccessfulExecutionTimestampMap
+	}
 	if o.TenantPrismaID != nil {
 		s.TenantPrismaID = o.TenantPrismaID
 	}
@@ -1251,6 +1293,9 @@ func (o *SparseCloudScheduledNetworkQuery) SetBSON(raw bson.Raw) error {
 	}
 	if s.SuccessfulExecutionTimestamp != nil {
 		o.SuccessfulExecutionTimestamp = s.SuccessfulExecutionTimestamp
+	}
+	if s.SuccessfulExecutionTimestampMap != nil {
+		o.SuccessfulExecutionTimestampMap = s.SuccessfulExecutionTimestampMap
 	}
 	if s.TenantPrismaID != nil {
 		o.TenantPrismaID = s.TenantPrismaID
@@ -1313,6 +1358,9 @@ func (o *SparseCloudScheduledNetworkQuery) ToPlain() elemental.PlainIdentifiable
 	}
 	if o.SuccessfulExecutionTimestamp != nil {
 		out.SuccessfulExecutionTimestamp = *o.SuccessfulExecutionTimestamp
+	}
+	if o.SuccessfulExecutionTimestampMap != nil {
+		out.SuccessfulExecutionTimestampMap = *o.SuccessfulExecutionTimestampMap
 	}
 	if o.TenantPrismaID != nil {
 		out.TenantPrismaID = *o.TenantPrismaID
@@ -1467,36 +1515,38 @@ func (o *SparseCloudScheduledNetworkQuery) DeepCopyInto(out *SparseCloudSchedule
 }
 
 type mongoAttributesCloudScheduledNetworkQuery struct {
-	ID                           bson.ObjectId      `bson:"_id,omitempty"`
-	CloudNetworkQuery            *CloudNetworkQuery `bson:"cloudnetworkquery"`
-	CreateTime                   time.Time          `bson:"createtime"`
-	Disabled                     bool               `bson:"disabled"`
-	LastExecutionTimestamp       time.Time          `bson:"lastexecutiontimestamp"`
-	MigrationsLog                map[string]string  `bson:"migrationslog,omitempty"`
-	Name                         string             `bson:"name"`
-	Namespace                    string             `bson:"namespace"`
-	PrismaCloudAlertRuleID       string             `bson:"prismacloudalertruleid"`
-	PrismaCloudPolicyID          string             `bson:"prismacloudpolicyid"`
-	SuccessfulExecutionTimestamp time.Time          `bson:"successfulexecutiontimestamp"`
-	TenantPrismaID               string             `bson:"tenantprismaid"`
-	UpdateTime                   time.Time          `bson:"updatetime"`
-	ZHash                        int                `bson:"zhash"`
-	Zone                         int                `bson:"zone"`
+	ID                              bson.ObjectId      `bson:"_id,omitempty"`
+	CloudNetworkQuery               *CloudNetworkQuery `bson:"cloudnetworkquery"`
+	CreateTime                      time.Time          `bson:"createtime"`
+	Disabled                        bool               `bson:"disabled"`
+	LastExecutionTimestamp          time.Time          `bson:"lastexecutiontimestamp"`
+	MigrationsLog                   map[string]string  `bson:"migrationslog,omitempty"`
+	Name                            string             `bson:"name"`
+	Namespace                       string             `bson:"namespace"`
+	PrismaCloudAlertRuleID          string             `bson:"prismacloudalertruleid"`
+	PrismaCloudPolicyID             string             `bson:"prismacloudpolicyid"`
+	SuccessfulExecutionTimestamp    time.Time          `bson:"successfulexecutiontimestamp"`
+	SuccessfulExecutionTimestampMap map[string]string  `bson:"successfulexecutiontimestampmap"`
+	TenantPrismaID                  string             `bson:"tenantprismaid"`
+	UpdateTime                      time.Time          `bson:"updatetime"`
+	ZHash                           int                `bson:"zhash"`
+	Zone                            int                `bson:"zone"`
 }
 type mongoAttributesSparseCloudScheduledNetworkQuery struct {
-	ID                           bson.ObjectId      `bson:"_id,omitempty"`
-	CloudNetworkQuery            *CloudNetworkQuery `bson:"cloudnetworkquery,omitempty"`
-	CreateTime                   *time.Time         `bson:"createtime,omitempty"`
-	Disabled                     *bool              `bson:"disabled,omitempty"`
-	LastExecutionTimestamp       *time.Time         `bson:"lastexecutiontimestamp,omitempty"`
-	MigrationsLog                *map[string]string `bson:"migrationslog,omitempty"`
-	Name                         *string            `bson:"name,omitempty"`
-	Namespace                    *string            `bson:"namespace,omitempty"`
-	PrismaCloudAlertRuleID       *string            `bson:"prismacloudalertruleid,omitempty"`
-	PrismaCloudPolicyID          *string            `bson:"prismacloudpolicyid,omitempty"`
-	SuccessfulExecutionTimestamp *time.Time         `bson:"successfulexecutiontimestamp,omitempty"`
-	TenantPrismaID               *string            `bson:"tenantprismaid,omitempty"`
-	UpdateTime                   *time.Time         `bson:"updatetime,omitempty"`
-	ZHash                        *int               `bson:"zhash,omitempty"`
-	Zone                         *int               `bson:"zone,omitempty"`
+	ID                              bson.ObjectId      `bson:"_id,omitempty"`
+	CloudNetworkQuery               *CloudNetworkQuery `bson:"cloudnetworkquery,omitempty"`
+	CreateTime                      *time.Time         `bson:"createtime,omitempty"`
+	Disabled                        *bool              `bson:"disabled,omitempty"`
+	LastExecutionTimestamp          *time.Time         `bson:"lastexecutiontimestamp,omitempty"`
+	MigrationsLog                   *map[string]string `bson:"migrationslog,omitempty"`
+	Name                            *string            `bson:"name,omitempty"`
+	Namespace                       *string            `bson:"namespace,omitempty"`
+	PrismaCloudAlertRuleID          *string            `bson:"prismacloudalertruleid,omitempty"`
+	PrismaCloudPolicyID             *string            `bson:"prismacloudpolicyid,omitempty"`
+	SuccessfulExecutionTimestamp    *time.Time         `bson:"successfulexecutiontimestamp,omitempty"`
+	SuccessfulExecutionTimestampMap *map[string]string `bson:"successfulexecutiontimestampmap,omitempty"`
+	TenantPrismaID                  *string            `bson:"tenantprismaid,omitempty"`
+	UpdateTime                      *time.Time         `bson:"updatetime,omitempty"`
+	ZHash                           *int               `bson:"zhash,omitempty"`
+	Zone                            *int               `bson:"zone,omitempty"`
 }

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -13703,7 +13703,7 @@ obtained.
 
 ##### `successfulExecutionTimestampMap`
 
-Type: `map[string]string`
+Type: `map[string]time`
 
 Mapping of last successful execution timestamp for every account.
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -13701,6 +13701,12 @@ Type: `time`
 Timestamp of the last time the query was successfully executed and results were
 obtained.
 
+##### `successfulExecutionTimestampMap`
+
+Type: `map[string]string`
+
+Mapping of last successful execution timestamp for every account.
+
 ##### `tenantPrismaID`
 
 Type: `string`

--- a/openapi3_autogen/cloudschedulednetworkquery.json
+++ b/openapi3_autogen/cloudschedulednetworkquery.json
@@ -55,6 +55,13 @@
             "format": "date-time",
             "type": "string"
           },
+          "successfulExecutionTimestampMap": {
+            "additionalProperties": {
+              "type": "date-time"
+            },
+            "description": "Mapping of last successful execution timestamp for every account.",
+            "type": "object"
+          },
           "tenantPrismaID": {
             "description": "Prisma ID of the tenant in which the Alert Rule is created.",
             "type": "string"

--- a/specs/_type.mapping
+++ b/specs/_type.mapping
@@ -800,6 +800,27 @@ map[string]string:
         }
       }
 
+map[string]time:
+  elemental:
+    type: map[string]time.Time
+    init: map[string]time.Time{}
+  jsonschema:
+    type: |-
+      {
+        "type": "object",
+        "additionalProperties": {
+          "type": "date-time"
+        }
+      }
+  openapi3:
+    type: |-
+      {
+        "type": "object",
+        "additionalProperties": {
+          "type": "date-time"
+        }
+      }
+
 network:
   elemental:
     type: '*net.IPNet'

--- a/specs/cloudschedulednetworkquery.spec
+++ b/specs/cloudschedulednetworkquery.spec
@@ -80,6 +80,13 @@ attributes:
     stored: true
     orderable: true
 
+  - name: successfulExecutionTimestampMap
+    description: Mapping of last successful execution timestamp for every account.
+    type: external
+    exposed: true
+    subtype: map[string]string
+    stored: true
+
   - name: tenantPrismaID
     description: Prisma ID of the tenant in which the Alert Rule is created.
     type: string

--- a/specs/cloudschedulednetworkquery.spec
+++ b/specs/cloudschedulednetworkquery.spec
@@ -84,7 +84,7 @@ attributes:
     description: Mapping of last successful execution timestamp for every account.
     type: external
     exposed: true
-    subtype: map[string]string
+    subtype: map[string]time
     stored: true
 
   - name: tenantPrismaID


### PR DESCRIPTION
## Description

Adding a new field for `successfulTimeStampMap` for every account

## Motivation and Context

Vargid scheduler schedules a bunch of policies for evaluation to NATS server which gets picked by Yeul Worker. The Yeul Worker picks up a job from the NATS server and executes the query for evaluation. It returns the result to Vargid API to aggregate and raise the alerts.

When Vargid API receives the `cloudschedulednetworkquery` response back, it updates the object's `successfulExecutionTimeStamp` with the time that it receives the response. This information is crucial in identifying alerts which are not raised in this successful run (i.e. while alert aggregation, the current set of alerts in this policy run is updated with the latest time stamp and the old alerts are left with the timestamp of the policy run in which it showed up. The resolver uses this information to resolve old alerts)

**Root cause**
However, in a recent optimization, we broke down big policy jobs (with multiple accounts) to smaller policy jobs (with smaller accounts) so that multiple jobs are scheduled for a single big policy job. If all the smaller policy jobs runs successfully, then there should be no problem. 

However, assume a case where you have a policy job **J** broken down into two jobs - **J1** and **J2**. When J1 executes successfully it updates the `successfulExecutionTimeStamp` with the latest timestamp and if J2 fails for some reason (yeul worker fails because of big accounts in J2), then it fails silently. This means that previously-raised alert records corresponding to J2 would be resolved even though there was no successful execution for the policy.

**The fix**
The core issue is we are using one timestamp `successfulExecutionTimeStamp` for the whole job when the accounts are being evaluated separately. We need a data structure to track the last successful execution for every account so that we can resolve alerts based on the `successfulExecutionTimeStamp` for the account associated to the alert.

A new data structure `successfulExecutionTimeStampMap` mapping `accounts to successfulExecTimestamp` is added to the query object and every time a CNQ response is recevied in Vargid API, then we would look at the accounts associated with the job and update the last successful execution time. While resolving alerts, we would look at the `successfulExecTimestamp` corresponding to the account.
## How Has This Been Tested?
 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
