### PR TITLE
New: Add stripNetworkEntries optional parameter to rendered policy workflow

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -6210,6 +6210,7 @@ Render a policy for a processing unit.
 Parameters:
 
 - `renderer` (`enum(v1 | v2)`): Select the network policy renderer to use.
+- `stripNetworkEntries` (`boolean`): If set to true, the entries field of all network rules will be stripped.
 
 ##### `GET /processingunits/:id/renderedpolicies`
 
@@ -6218,6 +6219,7 @@ Retrieves the policies for the processing unit.
 Parameters:
 
 - `renderer` (`enum(v1 | v2)`): Select the network policy renderer to use.
+- `stripNetworkEntries` (`boolean`): If set to true, the entries field of all network rules will be stripped.
 
 #### Attributes
 
@@ -6726,6 +6728,7 @@ Retrieves the policies for the processing unit.
 Parameters:
 
 - `renderer` (`enum(v1 | v2)`): Select the network policy renderer to use.
+- `stripNetworkEntries` (`boolean`): If set to true, the entries field of all network rules will be stripped.
 
 ##### `GET /processingunits/:id/services`
 

--- a/openapi3_autogen/processingunit.json
+++ b/openapi3_autogen/processingunit.json
@@ -592,6 +592,14 @@
                 "v2"
               ]
             }
+          },
+          {
+            "description": "If set to true, the entries field of all network rules will be stripped.",
+            "in": "query",
+            "name": "stripNetworkEntries",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {

--- a/openapi3_autogen/renderedpolicy.json
+++ b/openapi3_autogen/renderedpolicy.json
@@ -164,6 +164,14 @@
                 "v2"
               ]
             }
+          },
+          {
+            "description": "If set to true, the entries field of all network rules will be stripped.",
+            "in": "query",
+            "name": "stripNetworkEntries",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "requestBody": {

--- a/relationships_registry.go
+++ b/relationships_registry.go
@@ -4951,6 +4951,10 @@ func init() {
 							"v2",
 						},
 					},
+					{
+						Name: "stripNetworkEntries",
+						Type: "boolean",
+					},
 				},
 			},
 		},
@@ -4965,6 +4969,10 @@ func init() {
 							"v2",
 						},
 					},
+					{
+						Name: "stripNetworkEntries",
+						Type: "boolean",
+					},
 				},
 			},
 		},
@@ -4978,6 +4986,10 @@ func init() {
 							"v1",
 							"v2",
 						},
+					},
+					{
+						Name: "stripNetworkEntries",
+						Type: "boolean",
 					},
 				},
 			},

--- a/specs/processingunit.spec
+++ b/specs/processingunit.spec
@@ -337,6 +337,11 @@ relations:
         - v1
         - v2
 
+      - name: stripNetworkEntries
+        description: If set to true, the entries field of all network rules will be
+          stripped.
+        type: boolean
+
 - rest_name: service
   get:
     description: Retrieves the services used by a processing unit.

--- a/specs/root.spec
+++ b/specs/root.spec
@@ -1044,6 +1044,11 @@ relations:
         - v1
         - v2
 
+      - name: stripNetworkEntries
+        description: If set to true, the entries field of all network rules will be
+          stripped.
+        type: boolean
+
 - rest_name: rendertemplate
   create:
     description: Renders a new template.


### PR DESCRIPTION
#### Description
As a step towards moving the policy rendering to enforcerd, we want to avoid sending all the entries of related external networks with rendered policies. Since enforcer has a backwards compatibility requirement (~9 month lookback), we will add a new optional boolean parameter on create or retrieve requests `stripNetworkEntries`. When set to true, the entries of all related external networks in a rendered policy will have their entries field stripped to lighten the load.