### PR TITLE
Fixed: Lock golangci-lint on v1.17 due to generics

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -33,12 +33,12 @@ jobs:
         run: |
           # stay on an older version of golangci-lint which still builds against 1.17
           # This is due to the introduction of generics.
-          go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
 
       - name: setup-for-newer-go
         if: ${{ matrix.go > 1.17 }}
         run: |
-          go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
       - name: setup
         run: |

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -28,10 +28,21 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
+      - name: setup-for-older-go
+        if: ${{ matrix.go <= 1.17 }}
+        run: |
+          # stay on an older version of golangci-lint which still builds against 1.17
+          # This is due to the introduction of generics.
+          go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
+
+      - name: setup-for-newer-go
+        if: ${{ matrix.go > 1.17 }}
+        run: |
+          go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
       - name: setup
         run: |
           go version
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
           go install github.com/securego/gosec/cmd/gosec@latest
           #go install golang.org/x/tools/cmd/cover@latest
           go install github.com/axw/gocov/gocov@master


### PR DESCRIPTION
## Description
golangci-lint introduced changes that support generics, which is now causing build issues on golang v1.17.x (meaning it no longer supports this version). Isolating golang v1.17.x to newest supported golangci-lint version.