### PR TITLE
Update: Support golangci-lint v1.49.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,13 @@ lint:
 		--timeout 2m \
 		--disable-all \
 		--exclude-use-default=false \
+		--exclude=package-comments \
 		--enable=errcheck \
 		--enable=goimports \
 		--enable=ineffassign \
 		--enable=revive \
 		--enable=unused \
-		--enable=structcheck \
 		--enable=staticcheck \
-		--enable=varcheck \
-		--enable=deadcode \
 		--enable=unconvert \
 		--enable=misspell \
 		--enable=prealloc \


### PR DESCRIPTION
#### Description
With golangci-lint moving to v1.49.0, it enabled package comments which we do not do in practice. Also three linters have become deprecated as shown here:
```
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
```
This PR adjusts the linter to be happy with v1.49.0.