### PR TITLE
yeul/cloudgraph/create: introduce qry param 'neocna'

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -589,3 +589,4 @@ xip.io
 xxhash
 yaml
 yy
+neocna

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -10778,6 +10778,10 @@ connections in a particular namespace.
 Creates a cloud dependency graph based on ingested data and the required
 parameters.
 
+Parameters:
+
+- `neocna` (`boolean`): If set to true, neocna will be used regardless of whether tenant is onboarded to use neocna.
+
 ##### `GET /cloudnetworkqueries/:id/cloudgraphs`
 
 Initiates a calculation of the query and retrieves the results in CloudGraph.

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -10780,7 +10780,7 @@ parameters.
 
 Parameters:
 
-- `neocna` (`boolean`): If set to true, neocna will be used regardless of whether tenant is onboarded to use neocna.
+- `neocna` (`boolean`): If set to true, neocna will be used regardless of whether tenant is set to use neocna.
 
 ##### `GET /cloudnetworkqueries/:id/cloudgraphs`
 

--- a/openapi3_autogen/cloudgraph.json
+++ b/openapi3_autogen/cloudgraph.json
@@ -77,7 +77,7 @@
         "operationId": "create-a-new-cloudgraph",
         "parameters": [
           {
-            "description": "If set to true, neocna will be used regardless of whether tenant is onboarded to use neocna.",
+            "description": "If set to true, neocna will be used regardless of whether tenant is set to use neocna.",
             "in": "query",
             "name": "neocna",
             "schema": {

--- a/openapi3_autogen/cloudgraph.json
+++ b/openapi3_autogen/cloudgraph.json
@@ -75,6 +75,16 @@
       "post": {
         "description": "Creates a cloud dependency graph based on ingested data and the required\nparameters.",
         "operationId": "create-a-new-cloudgraph",
+        "parameters": [
+          {
+            "description": "If set to true, neocna will be used regardless of whether tenant is onboarded to use neocna.",
+            "in": "query",
+            "name": "neocna",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/relationships_registry.go
+++ b/relationships_registry.go
@@ -1052,7 +1052,14 @@ func init() {
 
 	relationshipsRegistry[CloudGraphIdentity] = &elemental.Relationship{
 		Create: map[string]*elemental.RelationshipInfo{
-			"root": {},
+			"root": {
+				Parameters: []elemental.ParameterDefinition{
+					{
+						Name: "neocna",
+						Type: "boolean",
+					},
+				},
+			},
 		},
 		RetrieveMany: map[string]*elemental.RelationshipInfo{
 			"cloudnetworkquery": {},

--- a/specs/root.spec
+++ b/specs/root.spec
@@ -254,7 +254,7 @@ relations:
       entries:
       - name: neocna
         description: If set to true, neocna will be used regardless of whether tenant
-          is onboarded to use neocna.
+          is set to use neocna.
         type: boolean
 
 - rest_name: cloudloadbalancer

--- a/specs/root.spec
+++ b/specs/root.spec
@@ -250,6 +250,12 @@ relations:
     description: |-
       Creates a cloud dependency graph based on ingested data and the required
       parameters.
+    parameters:
+      entries:
+      - name: neocna
+        description: If set to true, neocna will be used regardless of whether tenant
+          is onboarded to use neocna.
+        type: boolean
 
 - rest_name: cloudloadbalancer
   get:


### PR DESCRIPTION
This PR introduces a new qry param that can be set to force yeul to ignore check for whether tenant is onboarded to use neocna.