### PR TITLE
neocna/azureresource: build proper indexes

### DIFF
--- a/identities_registry.go
+++ b/identities_registry.go
@@ -690,9 +690,9 @@ var (
 		"azureresource": {
 			{":shard", ":unique", "zone", "zHash"},
 			{"namespace"},
+			{"namespace", "kind", "subscriptionID"},
 			{"namespace", "normalizedTags"},
 			{"namespace", "resourceID"},
-			{"namespace", "subscriptionID", "kind"},
 		},
 		"cachedflowreport": {
 			{":shard", "zone", "zHash", "_id"},

--- a/specs/azureresource.spec
+++ b/specs/azureresource.spec
@@ -23,5 +23,5 @@ indexes:
 - - namespace
   - resourceID
 - - namespace
-  - subscriptionID
   - kind
+  - subscriptionID


### PR DESCRIPTION
If we don't get resourceID to load a resources, we will always get kind and, optionally, subscriptionIDs.