### PR TITLE
[CNS-6354] neocna/gcpresourceattrs: add ComputeNetworkEndpointGroup

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -14838,7 +14838,7 @@ Default value:
 
 ##### `kind`
 
-Type: `enum(ComputeInstance | ComputeSubnetwork | ComputeNetwork | ComputeFirewall | ComputeFirewallPolicy | ComputeForwardingRule | ComputeBackendService | ComputeTargetHTTPProxy | ComputeTargetHTTPSProxy | ComputeTargetPool | ComputeRegion | ComputeZone | ComputeURLMap | ComputeInstanceGroup | ComputeTargetInstance | ResourceFolder | ResourceProject | Pending)`
+Type: `enum(ComputeInstance | ComputeSubnetwork | ComputeNetwork | ComputeFirewall | ComputeFirewallPolicy | ComputeForwardingRule | ComputeBackendService | ComputeTargetHTTPProxy | ComputeTargetHTTPSProxy | ComputeTargetPool | ComputeRegion | ComputeZone | ComputeURLMap | ComputeInstanceGroup | ComputeNetworkEndpointGroup | ComputeTargetInstance | ResourceFolder | ResourceProject | Pending)`
 
 The specific kind of the resource.
 

--- a/gcpasset.go
+++ b/gcpasset.go
@@ -57,6 +57,9 @@ const (
 	// GCPAssetKindComputeNetwork represents the value ComputeNetwork.
 	GCPAssetKindComputeNetwork GCPAssetKindValue = "ComputeNetwork"
 
+	// GCPAssetKindComputeNetworkEndpointGroup represents the value ComputeNetworkEndpointGroup.
+	GCPAssetKindComputeNetworkEndpointGroup GCPAssetKindValue = "ComputeNetworkEndpointGroup"
+
 	// GCPAssetKindComputeRegion represents the value ComputeRegion.
 	GCPAssetKindComputeRegion GCPAssetKindValue = "ComputeRegion"
 
@@ -609,7 +612,7 @@ func (o *GCPAsset) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("kind", string(o.Kind), []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"}, false); err != nil {
+	if err := elemental.ValidateStringInList("kind", string(o.Kind), []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -759,7 +762,7 @@ a resource's location or public IP addresses to support cross-cloud analysis.`,
 		Type:           "enum",
 	},
 	"Kind": {
-		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
+		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
 		BSONFieldName:  "kind",
 		ConvertedName:  "Kind",
 		DefaultValue:   GCPAssetKindPending,
@@ -993,7 +996,7 @@ a resource's location or public IP addresses to support cross-cloud analysis.`,
 		Type:           "enum",
 	},
 	"kind": {
-		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
+		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
 		BSONFieldName:  "kind",
 		ConvertedName:  "Kind",
 		DefaultValue:   GCPAssetKindPending,

--- a/gcpresource.go
+++ b/gcpresource.go
@@ -57,6 +57,9 @@ const (
 	// GCPResourceKindComputeNetwork represents the value ComputeNetwork.
 	GCPResourceKindComputeNetwork GCPResourceKindValue = "ComputeNetwork"
 
+	// GCPResourceKindComputeNetworkEndpointGroup represents the value ComputeNetworkEndpointGroup.
+	GCPResourceKindComputeNetworkEndpointGroup GCPResourceKindValue = "ComputeNetworkEndpointGroup"
+
 	// GCPResourceKindComputeRegion represents the value ComputeRegion.
 	GCPResourceKindComputeRegion GCPResourceKindValue = "ComputeRegion"
 
@@ -609,7 +612,7 @@ func (o *GCPResource) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("kind", string(o.Kind), []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"}, false); err != nil {
+	if err := elemental.ValidateStringInList("kind", string(o.Kind), []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -759,7 +762,7 @@ a resource's location or public IP addresses to support cross-cloud analysis.`,
 		Type:           "enum",
 	},
 	"Kind": {
-		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
+		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
 		BSONFieldName:  "kind",
 		ConvertedName:  "Kind",
 		DefaultValue:   GCPResourceKindPending,
@@ -993,7 +996,7 @@ a resource's location or public IP addresses to support cross-cloud analysis.`,
 		Type:           "enum",
 	},
 	"kind": {
-		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
+		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
 		BSONFieldName:  "kind",
 		ConvertedName:  "Kind",
 		DefaultValue:   GCPResourceKindPending,

--- a/openapi3_autogen/gcpasset.json
+++ b/openapi3_autogen/gcpasset.json
@@ -58,6 +58,7 @@
               "ComputeZone",
               "ComputeURLMap",
               "ComputeInstanceGroup",
+              "ComputeNetworkEndpointGroup",
               "ComputeTargetInstance",
               "ResourceFolder",
               "ResourceProject",

--- a/specs/@gcpresourceattrs.abs
+++ b/specs/@gcpresourceattrs.abs
@@ -59,6 +59,7 @@ attributes:
     - ComputeZone
     - ComputeURLMap
     - ComputeInstanceGroup
+    - ComputeNetworkEndpointGroup
     - ComputeTargetInstance
     - ResourceFolder
     - ResourceProject


### PR DESCRIPTION
Part of CNS-6354

Adds support for GCP networkEndpointGroups.