### PR TITLE
 [CNS-6352][CNS-6353] neocna/gcpresourceattrs: add ComputeTargetSSLProxy and ComputeTargetTCPProxy 

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -14850,7 +14850,7 @@ Default value:
 
 ##### `kind`
 
-Type: `enum(ComputeInstance | ComputeSubnetwork | ComputeNetwork | ComputeFirewall | ComputeFirewallPolicy | ComputeForwardingRule | ComputeBackendService | ComputeTargetHTTPProxy | ComputeTargetHTTPSProxy | ComputeTargetPool | ComputeRegion | ComputeZone | ComputeURLMap | ComputeInstanceGroup | ComputeNetworkEndpointGroup | ComputeTargetInstance | ResourceFolder | ResourceProject | Pending)`
+Type: `enum(ComputeInstance | ComputeSubnetwork | ComputeNetwork | ComputeFirewall | ComputeFirewallPolicy | ComputeForwardingRule | ComputeBackendService | ComputeTargetHTTPProxy | ComputeTargetHTTPSProxy | ComputeTargetPool | ComputeRegion | ComputeZone | ComputeURLMap | ComputeInstanceGroup | ComputeNetworkEndpointGroup | ComputeTargetInstance | ComputeTargetTCPProxy | ComputeTargetSSLProxy | ResourceFolder | ResourceProject | Pending)`
 
 The specific kind of the resource.
 

--- a/gcpasset.go
+++ b/gcpasset.go
@@ -78,6 +78,12 @@ const (
 	// GCPAssetKindComputeTargetPool represents the value ComputeTargetPool.
 	GCPAssetKindComputeTargetPool GCPAssetKindValue = "ComputeTargetPool"
 
+	// GCPAssetKindComputeTargetSSLProxy represents the value ComputeTargetSSLProxy.
+	GCPAssetKindComputeTargetSSLProxy GCPAssetKindValue = "ComputeTargetSSLProxy"
+
+	// GCPAssetKindComputeTargetTCPProxy represents the value ComputeTargetTCPProxy.
+	GCPAssetKindComputeTargetTCPProxy GCPAssetKindValue = "ComputeTargetTCPProxy"
+
 	// GCPAssetKindComputeURLMap represents the value ComputeURLMap.
 	GCPAssetKindComputeURLMap GCPAssetKindValue = "ComputeURLMap"
 
@@ -612,7 +618,7 @@ func (o *GCPAsset) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("kind", string(o.Kind), []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"}, false); err != nil {
+	if err := elemental.ValidateStringInList("kind", string(o.Kind), []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ComputeTargetTCPProxy", "ComputeTargetSSLProxy", "ResourceFolder", "ResourceProject", "Pending"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -762,7 +768,7 @@ a resource's location or public IP addresses to support cross-cloud analysis.`,
 		Type:           "enum",
 	},
 	"Kind": {
-		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
+		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ComputeTargetTCPProxy", "ComputeTargetSSLProxy", "ResourceFolder", "ResourceProject", "Pending"},
 		BSONFieldName:  "kind",
 		ConvertedName:  "Kind",
 		DefaultValue:   GCPAssetKindPending,
@@ -996,7 +1002,7 @@ a resource's location or public IP addresses to support cross-cloud analysis.`,
 		Type:           "enum",
 	},
 	"kind": {
-		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
+		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ComputeTargetTCPProxy", "ComputeTargetSSLProxy", "ResourceFolder", "ResourceProject", "Pending"},
 		BSONFieldName:  "kind",
 		ConvertedName:  "Kind",
 		DefaultValue:   GCPAssetKindPending,

--- a/gcpresource.go
+++ b/gcpresource.go
@@ -78,6 +78,12 @@ const (
 	// GCPResourceKindComputeTargetPool represents the value ComputeTargetPool.
 	GCPResourceKindComputeTargetPool GCPResourceKindValue = "ComputeTargetPool"
 
+	// GCPResourceKindComputeTargetSSLProxy represents the value ComputeTargetSSLProxy.
+	GCPResourceKindComputeTargetSSLProxy GCPResourceKindValue = "ComputeTargetSSLProxy"
+
+	// GCPResourceKindComputeTargetTCPProxy represents the value ComputeTargetTCPProxy.
+	GCPResourceKindComputeTargetTCPProxy GCPResourceKindValue = "ComputeTargetTCPProxy"
+
 	// GCPResourceKindComputeURLMap represents the value ComputeURLMap.
 	GCPResourceKindComputeURLMap GCPResourceKindValue = "ComputeURLMap"
 
@@ -612,7 +618,7 @@ func (o *GCPResource) Validate() error {
 		errors = errors.Append(err)
 	}
 
-	if err := elemental.ValidateStringInList("kind", string(o.Kind), []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"}, false); err != nil {
+	if err := elemental.ValidateStringInList("kind", string(o.Kind), []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ComputeTargetTCPProxy", "ComputeTargetSSLProxy", "ResourceFolder", "ResourceProject", "Pending"}, false); err != nil {
 		errors = errors.Append(err)
 	}
 
@@ -762,7 +768,7 @@ a resource's location or public IP addresses to support cross-cloud analysis.`,
 		Type:           "enum",
 	},
 	"Kind": {
-		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
+		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ComputeTargetTCPProxy", "ComputeTargetSSLProxy", "ResourceFolder", "ResourceProject", "Pending"},
 		BSONFieldName:  "kind",
 		ConvertedName:  "Kind",
 		DefaultValue:   GCPResourceKindPending,
@@ -996,7 +1002,7 @@ a resource's location or public IP addresses to support cross-cloud analysis.`,
 		Type:           "enum",
 	},
 	"kind": {
-		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ResourceFolder", "ResourceProject", "Pending"},
+		AllowedChoices: []string{"ComputeInstance", "ComputeSubnetwork", "ComputeNetwork", "ComputeFirewall", "ComputeFirewallPolicy", "ComputeForwardingRule", "ComputeBackendService", "ComputeTargetHTTPProxy", "ComputeTargetHTTPSProxy", "ComputeTargetPool", "ComputeRegion", "ComputeZone", "ComputeURLMap", "ComputeInstanceGroup", "ComputeNetworkEndpointGroup", "ComputeTargetInstance", "ComputeTargetTCPProxy", "ComputeTargetSSLProxy", "ResourceFolder", "ResourceProject", "Pending"},
 		BSONFieldName:  "kind",
 		ConvertedName:  "Kind",
 		DefaultValue:   GCPResourceKindPending,

--- a/openapi3_autogen/gcpasset.json
+++ b/openapi3_autogen/gcpasset.json
@@ -60,6 +60,8 @@
               "ComputeInstanceGroup",
               "ComputeNetworkEndpointGroup",
               "ComputeTargetInstance",
+              "ComputeTargetTCPProxy",
+              "ComputeTargetSSLProxy",
               "ResourceFolder",
               "ResourceProject",
               "Pending"

--- a/specs/@gcpresourceattrs.abs
+++ b/specs/@gcpresourceattrs.abs
@@ -61,6 +61,8 @@ attributes:
     - ComputeInstanceGroup
     - ComputeNetworkEndpointGroup
     - ComputeTargetInstance
+    - ComputeTargetTCPProxy
+    - ComputeTargetSSLProxy
     - ResourceFolder
     - ResourceProject
     - Pending


### PR DESCRIPTION

Part of CNS-6352 and CNS-6353

Adds support for GCP targetTcpProxy and targetSslProxy resources.