### PR TITLE
removed regex validation on nativeID

### DIFF
--- a/custom_validations.go
+++ b/custom_validations.go
@@ -1776,19 +1776,11 @@ func IsAddressAzureReserved(address string) (bool, error) {
 	return false, nil
 }
 
-// nativeIDRegex is the regular expression to check the format of the nativeID.
-var nativeIDRegex = regexp.MustCompile(`^[a-zA-Z0-9-_#+.\/:@{}"\\,]+$`)
-
 // ValidateCloudNodeEntity validates the CloudNode entity and all the attribute relations.
 func ValidateCloudNodeEntity(c *CloudNode) error {
 
-	switch c.Type {
-	case CloudNodeTypeScaleGroup:
-		// Do nothing.
-	default:
-		if !nativeIDRegex.MatchString(c.NativeID) {
-			return makeValidationError("nativeID", fmt.Sprintf("'%s'is not a valid tag", c.NativeID))
-		}
+	if len(c.NativeID) == 0 {
+		return makeValidationError("nativeID", "Attribute 'nativeID' must not be empty")
 	}
 
 	if len([]byte(c.NativeID)) >= 512 {

--- a/custom_validations_test.go
+++ b/custom_validations_test.go
@@ -5398,7 +5398,7 @@ func TestValidateCloudNodeEntity(t *testing.T) {
 				NativeID: "a b",
 				Type:     CloudNodeTypeNetworkRuleSet,
 			},
-			true,
+			false,
 		},
 		{
 			"invalid",


### PR DESCRIPTION
## Description
removed regex check on nativeID field as many objects from different cloud providers allow special characters and space
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
