### PR TITLE
Update: Bump golang build/support to v1.20 and v1.21

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -19,7 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 1.19
+          - 1.20
+          - 1.21
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -19,12 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 1.20
-          - 1.21
+          - '1.20'
+          - '1.21'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module go.aporeto.io/gaia
 
-go 1.19
+go 1.20
 
 // Aporeto
-require go.aporeto.io/elemental v1.122.1-0.20230127211758-51fb47178716
+require go.aporeto.io/elemental v1.123.0
 
 require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/ugorji/go/codec v1.2.8 h1:sgBJS6COt0b/P40VouWKdseidkDgHxYGm0SAglUHfP0
 github.com/ugorji/go/codec v1.2.8/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/yl2chen/cidranger v1.0.2 h1:lbOWZVCG1tCRX4u24kuM1Tb4nHqWkDxwLdoS+SevawU=
 github.com/yl2chen/cidranger v1.0.2/go.mod h1:9U1yz7WPYDwf0vpNWFaeRh0bjwz5RVgRy/9UEQfHl0g=
-go.aporeto.io/elemental v1.122.1-0.20230127211758-51fb47178716 h1:S3Ts+DvkrAxMuVU6iDtkHGdHj15b44juna+AjGzU9TU=
-go.aporeto.io/elemental v1.122.1-0.20230127211758-51fb47178716/go.mod h1:dKRrJ+ZLwOE0VIbgfoLvskXKvob3h2eSRJijG9eO+9o=
+go.aporeto.io/elemental v1.123.0 h1:yKsB9YNTHrPq/39EMUoxBdbXDsuT55MrPzLMVVSR7G8=
+go.aporeto.io/elemental v1.123.0/go.mod h1:TeftndRimmpTcaBhcdGWVoaRbBgNfGIcl791KRrR3Xw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
#### Description
Bumping go.mod minimum supported version to v1.20 and moving build checks to v1.20 and v1.21

https://go.dev/doc/go1.21