### PR TITLE
[CNS-8149] support not_in filter for asset tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ lint:
 		--timeout 2m \
 		--disable-all \
 		--exclude-use-default=false \
+		--exclude=dot-imports \
 		--exclude=package-comments \
 		--enable=errcheck \
 		--enable=goimports \

--- a/cloudnetworkqueryfilter.go
+++ b/cloudnetworkqueryfilter.go
@@ -70,6 +70,10 @@ type CloudNetworkQueryFilter struct {
 	// resourceType Endpoint.
 	ImageIDs []string `json:"imageIDs,omitempty" msgpack:"imageIDs,omitempty" bson:"imageids,omitempty" mapstructure:"imageIDs,omitempty"`
 
+	// A list of tags that exclude the matching endpoints for the query. These tags
+	// refer to the tags attached to the resources in the cloud provider definitions.
+	NotTags []string `json:"notTags,omitempty" msgpack:"notTags,omitempty" bson:"nottags,omitempty" mapstructure:"notTags,omitempty"`
+
 	// The exact object that the search applies. If ObjectIDs are defined, the rest of
 	// the fields are ignored. An object ID can refer to an instance, VPC endpoint, or
 	// network interface.
@@ -139,6 +143,7 @@ func NewCloudNetworkQueryFilter() *CloudNetworkQueryFilter {
 		AccountIDs:         []string{},
 		CloudTypes:         []string{},
 		ImageIDs:           []string{},
+		NotTags:            []string{},
 		ObjectIDs:          []string{},
 		PaasTypes:          []string{},
 		Regions:            []string{},
@@ -172,6 +177,7 @@ func (o *CloudNetworkQueryFilter) GetBSON() (any, error) {
 	s.AccountIDs = o.AccountIDs
 	s.CloudTypes = o.CloudTypes
 	s.ImageIDs = o.ImageIDs
+	s.NotTags = o.NotTags
 	s.ObjectIDs = o.ObjectIDs
 	s.PaasTypes = o.PaasTypes
 	s.ProductInfoType = o.ProductInfoType
@@ -212,6 +218,7 @@ func (o *CloudNetworkQueryFilter) SetBSON(raw bson.Raw) error {
 	o.AccountIDs = s.AccountIDs
 	o.CloudTypes = s.CloudTypes
 	o.ImageIDs = s.ImageIDs
+	o.NotTags = s.NotTags
 	o.ObjectIDs = s.ObjectIDs
 	o.PaasTypes = s.PaasTypes
 	o.ProductInfoType = s.ProductInfoType
@@ -327,6 +334,8 @@ func (o *CloudNetworkQueryFilter) ValueForAttribute(name string) any {
 		return o.CloudTypes
 	case "imageIDs":
 		return o.ImageIDs
+	case "notTags":
+		return o.NotTags
 	case "objectIDs":
 		return o.ObjectIDs
 	case "paasTypes":
@@ -470,6 +479,18 @@ account as provided by the cloud provider. One or more IDs can be included.`,
 resourceType Endpoint.`,
 		Exposed: true,
 		Name:    "imageIDs",
+		Stored:  true,
+		SubType: "string",
+		Type:    "list",
+	},
+	"NotTags": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "nottags",
+		ConvertedName:  "NotTags",
+		Description: `A list of tags that exclude the matching endpoints for the query. These tags
+refer to the tags attached to the resources in the cloud provider definitions.`,
+		Exposed: true,
+		Name:    "notTags",
 		Stored:  true,
 		SubType: "string",
 		Type:    "list",
@@ -745,6 +766,18 @@ resourceType Endpoint.`,
 		SubType: "string",
 		Type:    "list",
 	},
+	"nottags": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "nottags",
+		ConvertedName:  "NotTags",
+		Description: `A list of tags that exclude the matching endpoints for the query. These tags
+refer to the tags attached to the resources in the cloud provider definitions.`,
+		Exposed: true,
+		Name:    "notTags",
+		Stored:  true,
+		SubType: "string",
+		Type:    "list",
+	},
 	"objectids": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "objectids",
@@ -911,6 +944,7 @@ type mongoAttributesCloudNetworkQueryFilter struct {
 	AccountIDs         []string                                 `bson:"accountids,omitempty"`
 	CloudTypes         []string                                 `bson:"cloudtypes,omitempty"`
 	ImageIDs           []string                                 `bson:"imageids,omitempty"`
+	NotTags            []string                                 `bson:"nottags,omitempty"`
 	ObjectIDs          []string                                 `bson:"objectids,omitempty"`
 	PaasTypes          []string                                 `bson:"paastypes,omitempty"`
 	ProductInfoType    string                                   `bson:"productinfotype,omitempty"`

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -12766,6 +12766,13 @@ Type: `[]string`
 A list of imageIDs that endpoints can be filtered with. Applies only to
 resourceType Endpoint.
 
+##### `notTags`
+
+Type: `[]string`
+
+A list of tags that exclude the matching endpoints for the query. These tags
+refer to the tags attached to the resources in the cloud provider definitions.
+
 ##### `objectIDs`
 
 Type: `[]string`

--- a/openapi3_autogen/cloudnetworkqueryfilter.json
+++ b/openapi3_autogen/cloudnetworkqueryfilter.json
@@ -80,6 +80,13 @@
             },
             "type": "array"
           },
+          "notTags": {
+            "description": "A list of tags that exclude the matching endpoints for the query. These tags\nrefer to the tags attached to the resources in the cloud provider definitions.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "objectIDs": {
             "description": "The exact object that the search applies. If ObjectIDs are defined, the rest of\nthe fields are ignored. An object ID can refer to an instance, VPC endpoint, or\nnetwork interface.",
             "items": {

--- a/specs/+cloudnetworkqueryfilter.spec
+++ b/specs/+cloudnetworkqueryfilter.spec
@@ -109,6 +109,16 @@ attributes:
     stored: true
     omit_empty: true
 
+  - name: notTags
+    description: |-
+      A list of tags that exclude the matching endpoints for the query. These tags
+      refer to the tags attached to the resources in the cloud provider definitions.
+    type: list
+    exposed: true
+    subtype: string
+    stored: true
+    omit_empty: true
+
   - name: objectIDs
     description: |-
       The exact object that the search applies. If ObjectIDs are defined, the rest of


### PR DESCRIPTION
Adds a `notTags` attribute to `cloudnetworkqueryfilter` to store asset tags that should be selected against using the `not_in` operator in RQL.

Also excludes dot import checks with golangci-lint which have started to error out in the latest version.