### PR TITLE
adding prismaID+k8sID as the index for k8sresources in mongo

### DIFF
--- a/identities_registry.go
+++ b/identities_registry.go
@@ -1240,6 +1240,7 @@ var (
 			{"namespace", "normalizedTags"},
 			{"namespace", "uid"},
 			{"prismaID"},
+			{"prismaID", "k8sID"},
 			{"prismaID", "kind", "cloudProvider"},
 			{"prismaID", "kind", "cloudProvider", "accountID", "clusterID", "k8sNamespace"},
 			{"prismaID", "kind", "cloudProvider", "accountID", "k8sNamespace"},

--- a/specs/k8sresource.spec
+++ b/specs/k8sresource.spec
@@ -70,3 +70,5 @@ indexes:
 - - prismaID
   - kind
   - cloudProvider
+- - prismaID
+  - k8sID


### PR DESCRIPTION
## Description

adding prismaID+k8sID as the index for k8sresources in mongo. This got left out from the previous PR (https://github.com/PaloAltoNetworks/gaia/pull/967)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
